### PR TITLE
CMakeLists: update to eigenpy 2.7.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ COMPUTE_PROJECT_ARGS(PROJECT_ARGS LANGUAGES CXX)
 project(${PROJECT_NAME} ${PROJECT_ARGS})
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/boost.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/python.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/ide.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/apple.cmake)
 include(CMakeDependentOption)
@@ -90,11 +89,11 @@ EXPORT_BOOST_DEFAULT_OPTIONS()
 ADD_PROJECT_DEPENDENCY(Boost REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
 
 if(BUILD_PYTHON_INTERFACE)
-  FINDPYTHON(REQUIRED)
+  set(PYTHON_COMPONENTS Interpreter Development.Module NumPy Development)
   set(PYLIB_NAME "py${PROJECT_NAME}")
+  ADD_PROJECT_DEPENDENCY(eigenpy 2.7.10 REQUIRED)
+  FINDPYTHON(REQUIRED)
   set(${PYLIB_NAME}_INSTALL_DIR ${PYTHON_SITELIB}/${PROJECT_NAME})
-  SEARCH_FOR_BOOST_PYTHON(REQUIRED)
-  ADD_PROJECT_DEPENDENCY(eigenpy 2.7.2 REQUIRED PKG_CONFIG_REQUIRES "eigenpy >= 2.7.2")
 
   execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import platform; print(platform.python_implementation())"
     OUTPUT_VARIABLE _python_implementation_value


### PR DESCRIPTION
solve problems with Python:NumPy3 not found.