### PR TITLE
Don't build tests when BUILD_TESTING is OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,9 @@ if(BUILD_PYTHON_INTERFACE)
 endif()
 
 add_subdirectory(examples)
-add_subdirectory(tests)
+IF(BUILD_TESTING)
+  add_subdirectory(tests)
+ENDIF()
 
 # --- PACKAGING ----------------------------------------------------------------
 macro(EXPORT_VARIABLE var_name var_value)


### PR DESCRIPTION
This removes the dependency on google/benchmark for users who don't need to re-run unit tests.