### PR TITLE
Fix package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -3,6 +3,8 @@
   <name>proxnlp</name>
   <version>0.2.3</version>
   <maintainer email="wilson.jallet@laas.fr">Wilson Jallet</maintainer>
+  <description> A primal-dual augmented Lagrangian-type solver for nonlinear programming on manifolds.</description>
+  <license>tbd</license>
 
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>


### PR DESCRIPTION
Add `description` and `lisence` tag in `package.xml` to follow the specifications (http://wiki.ros.org/catkin/package.xml)

This is particularly important when using ROS/catkin from conda since it checks all the cmake packages installed in the environment, and if one `package.xml` doesn't follow the spec, catkin crashes (silently most of the time...).