### PR TITLE
Change loop index type

### DIFF
--- a/src/ldlt-allocator.cpp
+++ b/src/ldlt-allocator.cpp
@@ -16,10 +16,10 @@ create_default_block_structure(const std::vector<isize> &dims_primal,
   SymbolicBlockMatrix structure(nblocks, nblocks);
   isize *segment_lens = structure.segment_lens;
 
-  for (uint i = 0; i < nprim_blocks; ++i) {
+  for (isize i = 0; i < nprim_blocks; ++i) {
     segment_lens[i] = dims_primal[i];
   }
-  for (uint i = 0; i < ndual_blocks; ++i) {
+  for (isize i = 0; i < ndual_blocks; ++i) {
     segment_lens[i + nprim_blocks] = dims_dual[i];
   }
 


### PR DESCRIPTION
The loop index type was `uint`, but `uint` type is not defined anywhere in the project (and I don't find the dependency where it is defined). `isize` is the new type used in the loop. Similarly to the other loops, and restored from an old version of the code (see commit https://github.com/Simple-Robotics/proxnlp/commit/a63d2ee1aa97b620e80be1673380efbb1be6372f)