### PR TITLE
Define inline macro for other compilers than GCC

### DIFF
--- a/include/proxnlp/macros.hpp
+++ b/include/proxnlp/macros.hpp
@@ -20,4 +20,8 @@
 /// @brief Exiting performance-critical code.
 #define PROXNLP_NOMALLOC_END PROXNLP_EIGEN_ALLOW_MALLOC(true)
 
+#ifdef __GNUC__
 #define PROXNLP_INLINE inline __attribute__((always_inline))
+#else
+#define PROXNLP_INLINE inline
+#endif


### PR DESCRIPTION
`__attribute__((always_inline))` seems to be valid only for gcc. I guess there is a "always inline" equivalent for other compilers too, but I am only interested in the compilation now.