### PR TITLE
Optional examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ endif()
 option(BUILD_PYTHON_INTERFACE "Build the Python bindings" ON)
 option(BUILD_WITH_VERSION_SUFFIX "Build libraries with version appended to suffix" OFF)
 option(ENABLE_TEMPLATE_INSTANTIATION "Template instantiation of the main library" ON)
-option(BUILD_WITH_EXAMPLES "Build the examples" ON)
+option(BUILD_EXAMPLES "Build the examples" ON)
 
 # --- OPTIONAL DEPENDENCIES -------------------------
 option(BUILD_WITH_PINOCCHIO_SUPPORT "Build the library with support for Pinocchio" ON)
@@ -219,7 +219,7 @@ if(BUILD_PYTHON_INTERFACE)
   add_subdirectory(python)
 endif()
 
-if (BUILD_WITH_EXAMPLES)
+if (BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 if(BUILD_TESTING)


### PR DESCRIPTION
Examples are not necessary if the library is just a dependency in a project. In addition, examples don't compile with MSVC.