### PR TITLE
Fix compilation on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,10 @@ function(create_library)
   endif(BUILD_WITH_PROXSUITE)
   target_include_directories(${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
 
+  if (MSVC)
+    target_compile_options(${PROJECT_NAME} PUBLIC "/bigobj")
+  endif(MSVC)
+
   foreach(headerFile ${LIB_HEADERS})
     string(REGEX REPLACE "${PROJECT_SOURCE_DIR}/" "" headerFileRelative ${headerFile})
     get_filename_component(headerPath ${headerFileRelative} PATH)

--- a/include/proxnlp/results.hpp
+++ b/include/proxnlp/results.hpp
@@ -5,6 +5,7 @@
 #include "proxnlp/problem-base.hpp"
 
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 
 namespace proxnlp {
 
@@ -59,7 +60,7 @@ template <typename _Scalar> struct ResultsTpl {
 
   friend std::ostream &operator<<(std::ostream &oss,
                                   const ResultsTpl<Scalar> &self) {
-    oss << "Results {" << fmt::format("\n  convergence:   {},", self.converged)
+    oss << "Results {" << fmt::format("\n  convergence:   {},", fmt::underlying(self.converged))
         << fmt::format("\n  merit:         {:.3e},", self.merit)
         << fmt::format("\n  value:         {:.3e},", self.value)
         << fmt::format("\n  num_iters:     {:d},", self.num_iters)


### PR DESCRIPTION
Documentation on the `bigobj` compilation option: https://learn.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=msvc-170

Fix the errors due to fmt.

fmt also causes compilation errors in the examples, but that will be in another PR.