### PR TITLE
Update agent labels to avoid running on M1 agent

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ defaults:
     shell: bash -leo pipefail {0} {0}
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: self-hosted-linux-x64
     steps:
 
     - uses: actions/cache@v3
@@ -47,7 +47,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: self-hosted
+    runs-on: self-hosted-linux-x64
     steps:
     - run: |
         micromamba activate
@@ -58,7 +58,7 @@ jobs:
   cleanup:
     name: Cleanup
     needs: [build, test]
-    runs-on: self-hosted
+    runs-on: self-hosted-linux-x64
     if: always()
     steps:
     - run: |


### PR DESCRIPTION
macos-m1 agent has been added and have self-hosted label.

This could lead CI code dedicated to Linux agent to be run on MacOS M1.
