### PR TITLE
Upgrade eigenpy to 3.2.0

### DIFF
--- a/.github/workflows/conda/conda-env.yml
+++ b/.github/workflows/conda/conda-env.yml
@@ -7,7 +7,7 @@ dependencies:
   - ninja
   - cxx-compiler
   - ccache
-  - eigenpy
+  - eigenpy>=3.2
   - pinocchio
   - eigen
   - fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Changed the minimum version of eigenpy to 3.2.0
+
 ## [0.3.1] - 2023-12-21
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ add_project_dependency(Boost REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
 
 if(BUILD_PYTHON_INTERFACE)
   set(PYTHON_COMPONENTS Interpreter Development.Module NumPy Development)
-  add_project_dependency(eigenpy 3.1.0 REQUIRED PKG_CONFIG_REQUIRES "eigenpy >= 3.1.0")
+  add_project_dependency(eigenpy 3.2.0 REQUIRED PKG_CONFIG_REQUIRES "eigenpy >= 3.2.0")
 
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} -c "import platform; print(platform.python_implementation())"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cmake --build build/ --config Release --target install
 **Dependencies**
 
 * CMake (with the [JRL CMake modules](https://github.com/jrl-umi3218/jrl-cmakemodules))
-* [eigenpy](https://github.com/stack-of-tasks/eigenpy)>=3.1.0 | [conda](https://anaconda.org/conda-forge/eigenpy)
+* [eigenpy](https://github.com/stack-of-tasks/eigenpy)>=3.2.0 | [conda](https://anaconda.org/conda-forge/eigenpy)
 * [pinocchio](https://github.com/stack-of-tasks/eigenpy) | [conda](https://anaconda.org/conda-forge/pinocchio)
 * Eigen>=3.3.7
 * [fmtlib](https://github.com/fmtlib/fmt)>=9.1.0, <11


### PR DESCRIPTION
This PR upgrades the eigenpy dependency to 3.2.0