### PR TITLE
Add missing pinocchio/eigen dependencies in xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add missing dependencies in `package.xml`: pinocchio, eigen.
+
 ## [0.3.4] - 2024-01-19
 
 ### Fixed

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,9 @@
   <depend>python3</depend>
   <depend>python3-numpy</depend>
   <depend>boost</depend>
+  <depend>eigen</depend>
   <depend>eigenpy</depend>
+  <depend>pinocchio</depend>
   <depend>fmtlib</depend>
 
   <buildtool_depend>cmake</buildtool_depend>


### PR DESCRIPTION
Hello,

Small PR to add missing dependencies in `package.xml` (such that, for instance, the packages get built in the correct order when using [catkin](https://catkin-tools.readthedocs.io/en/latest/) or [colcon](https://colcon.readthedocs.io/en/released/) - which was my use case)

Cheers