### PR TITLE
Fix memory allocation in bunch_kaufman_in_place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add missing dependencies in `package.xml`: pinocchio, eigen.
 * Fix `ConstraintObjectTpl::operator==` constness (mandatory for eigenpy 3.3)
 * Corner case in `BunchKaufman<>` decomposition class when number of lhs rows is 1
+* Memory allocation in `BunchKaufman<>` ([#66](https://github.com/Simple-Robotics/proxsuite-nlp/pull/66))
 
 ### Added
 

--- a/tests/cholesky-dense-bench.cpp
+++ b/tests/cholesky-dense-bench.cpp
@@ -53,7 +53,7 @@ void BM_indefinite(benchmark::State &state) {
   for (auto _ : state) {
     long n = state.range(0);
     state.PauseTiming();
-    MatrixType a = sampleGaussianOrhogonalEnsemble(n);
+    MatrixType a = sampleGaussianOrthogonalEnsemble(n);
     MatrixType b = Eigen::Rand::normal<MatrixType>(n, 4, rng);
     state.ResumeTiming();
 

--- a/tests/util.cpp
+++ b/tests/util.cpp
@@ -1,6 +1,6 @@
 #include "./util.hpp"
 
-MatrixXs sampleGaussianOrhogonalEnsemble(Eigen::Index n) {
+MatrixXs sampleGaussianOrthogonalEnsemble(Eigen::Index n) {
   Eigen::Rand::P8_mt19937_64 urng{42};
   MatrixXs A = Eigen::Rand::normal<MatrixXs>(n, n, urng);
   double Z = std::sqrt(2.0 * int(n));

--- a/tests/util.hpp
+++ b/tests/util.hpp
@@ -13,7 +13,7 @@ PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
 } // namespace
 
 /// Sample for the GOE (Gaussian Orthogonal Ensemble)
-MatrixXs sampleGaussianOrhogonalEnsemble(Eigen::Index n);
+MatrixXs sampleGaussianOrthogonalEnsemble(Eigen::Index n);
 
 /// Get a random, symmetric block-sparse matrix
 MatrixXs getRandomSymmetricBlockMatrix(SymbolicBlockMatrix const &sym);


### PR DESCRIPTION
This PR fixes the creation of a workspace matrix on-the-fly in the Bunch-Kaufman solver.