### PR TITLE
Add product of constraint sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Added `ConstraintSetProduct` ([#74](https://github.com/Simple-Robotics/proxsuite-nlp/pull/74))
+
 ### Changed
 
 * `EqualityConstraint`/`NegativeOrthant` template classes changed to `EqualityConstraintTpl`/`NegativeOrthantTpl`

--- a/bindings/python/expose-constraint.cpp
+++ b/bindings/python/expose-constraint.cpp
@@ -124,6 +124,8 @@ static void exposeConstraintTypes() {
 
   exposeSpecificConstraintSet<ConstraintSetProduct>(
       "ConstraintSetProduct", "Cartesian product of constraint sets.")
+      .def(bp::init<std::vector<ConstraintSet *>, std::vector<Eigen::Index>>(
+          ("self"_a, "components", "blockSizes")))
       .add_property("blockSizes",
                     bp::make_function(&ConstraintSetProduct::blockSizes,
                                       bp::return_internal_reference<>()),

--- a/bindings/python/expose-constraint.cpp
+++ b/bindings/python/expose-constraint.cpp
@@ -126,6 +126,9 @@ static void exposeConstraintTypes() {
       "ConstraintSetProduct", "Cartesian product of constraint sets.")
       .def(bp::init<std::vector<ConstraintSet *>, std::vector<Eigen::Index>>(
           ("self"_a, "components", "blockSizes")))
+      .add_property("components",
+                    bp::make_function(&ConstraintSetProduct::components,
+                                      bp::return_internal_reference<>()))
       .add_property("blockSizes",
                     bp::make_function(&ConstraintSetProduct::blockSizes,
                                       bp::return_internal_reference<>()),

--- a/include/proxsuite-nlp/modelling/constraints.hpp
+++ b/include/proxsuite-nlp/modelling/constraints.hpp
@@ -4,6 +4,7 @@
 #include "proxsuite-nlp/modelling/constraints/negative-orthant.hpp"
 #include "proxsuite-nlp/modelling/constraints/box-constraint.hpp"
 #include "proxsuite-nlp/modelling/constraints/l1-penalty.hpp"
+#include "proxsuite-nlp/modelling/constraints/constraint-set-product.hpp"
 
 #ifdef PROXSUITE_NLP_ENABLE_TEMPLATE_INSTANTIATION
 #include "proxsuite-nlp/modelling/constraints.txx"

--- a/include/proxsuite-nlp/modelling/constraints.txx
+++ b/include/proxsuite-nlp/modelling/constraints.txx
@@ -19,6 +19,8 @@ extern template struct PROXSUITE_NLP_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
     BoxConstraintTpl<context::Scalar>;
 extern template struct PROXSUITE_NLP_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
     NonsmoothPenaltyL1Tpl<context::Scalar>;
+extern template struct PROXSUITE_NLP_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    ConstraintSetProductTpl<context::Scalar>;
 
 } // namespace nlp
 } // namespace proxsuite

--- a/include/proxsuite-nlp/modelling/constraints/constraint-set-product.hpp
+++ b/include/proxsuite-nlp/modelling/constraints/constraint-set-product.hpp
@@ -38,6 +38,15 @@ struct ConstraintSetProductTpl : ConstraintSetBase<Scalar> {
   using Base = ConstraintSetBase<Scalar>;
   using ActiveType = typename Base::ActiveType;
 
+  ConstraintSetProductTpl(const std::vector<Base *> components,
+                          const std::vector<Eigen::Index> &blockSizes)
+      : m_components(components), m_blockSizes(blockSizes) {
+    if (components.size() != blockSizes.size()) {
+      PROXSUITE_NLP_RUNTIME_ERROR("Number of components and corresponding "
+                                  "block sizes should be the same.");
+    }
+  }
+
   Scalar evaluate(const ConstVectorRef &zproj) const override {
     Scalar res = 0.;
     for (std::size_t i = 0; i < m_components.size(); i++) {

--- a/include/proxsuite-nlp/modelling/constraints/constraint-set-product.hpp
+++ b/include/proxsuite-nlp/modelling/constraints/constraint-set-product.hpp
@@ -100,6 +100,7 @@ struct ConstraintSetProductTpl : ConstraintSetBase<Scalar> {
     }
   }
 
+  const std::vector<Base *> &components() const { return m_components; }
   const std::vector<Eigen::Index> &blockSizes() const { return m_blockSizes; }
 
 private:

--- a/include/proxsuite-nlp/modelling/constraints/constraint-set-product.hpp
+++ b/include/proxsuite-nlp/modelling/constraints/constraint-set-product.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "proxsuite-nlp/constraint-base.hpp"
+
+namespace proxsuite {
+namespace nlp {
+template <typename Derived>
+auto blockMatrixGetRow(const Eigen::MatrixBase<Derived> &matrix,
+                       const std::vector<Eigen::Index> &rowBlockSizes,
+                       std::size_t rowIdx) {
+  Eigen::Index startIdx = 0;
+  for (std::size_t kk = 0; kk < rowIdx; kk++) {
+    startIdx += rowBlockSizes[kk];
+  }
+  return matrix.const_cast_derived().middleRows(startIdx,
+                                                rowBlockSizes[rowIdx]);
+}
+
+template <typename Derived>
+auto blockVectorGetRow(const Eigen::MatrixBase<Derived> &matrix,
+                       const std::vector<Eigen::Index> &blockSizes,
+                       std::size_t blockIdx) {
+  EIGEN_STATIC_ASSERT_VECTOR_ONLY(Derived);
+  Eigen::Index startIdx = 0;
+  for (std::size_t kk = 0; kk < blockIdx; kk++) {
+    startIdx += blockSizes[kk];
+  }
+  return matrix.const_cast_derived().segment(startIdx, blockSizes[blockIdx]);
+}
+
+/// @brief Cartesian product of multiple constraint sets.
+/// This class makes computing multipliers and Jacobian matrix projections more
+/// convenient.
+/// @warning This struct contains a non-owning vector of its component sets.
+template <typename Scalar>
+struct ConstraintSetProductTpl : ConstraintSetBase<Scalar> {
+  PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
+  using Base = ConstraintSetBase<Scalar>;
+  using ActiveType = typename Base::ActiveType;
+
+  Scalar evaluate(const ConstVectorRef &zproj) const override {
+    Scalar res = 0.;
+    for (std::size_t i = 0; i < m_components.size(); i++) {
+      auto zblock = blockVectorGetRow(zproj, m_blockSizes, i);
+      res += m_components[i]->evaluate(zblock);
+    }
+    return res;
+  }
+
+  void projection(const ConstVectorRef &z, VectorRef zout) const override {
+    for (std::size_t i = 0; i < m_components.size(); i++) {
+      ConstVectorRef inblock = blockVectorGetRow(z, m_blockSizes, i);
+      VectorRef outblock = blockVectorGetRow(zout, m_blockSizes, i);
+      m_components[i]->projection(inblock, outblock);
+    }
+  }
+
+  void normalConeProjection(const ConstVectorRef &z,
+                            VectorRef zout) const override {
+    for (std::size_t i = 0; i < m_components.size(); i++) {
+      ConstVectorRef inblock = blockVectorGetRow(z, m_blockSizes, i);
+      VectorRef outblock = blockVectorGetRow(zout, m_blockSizes, i);
+      m_components[i]->normalConeProjection(inblock, outblock);
+    }
+  }
+
+  void applyProjectionJacobian(const ConstVectorRef &z,
+                               MatrixRef Jout) const override {
+    for (std::size_t i = 0; i < m_components.size(); i++) {
+      ConstVectorRef inblock = blockVectorGetRow(z, m_blockSizes, i);
+      MatrixRef outblock = blockMatrixGetRow(Jout, m_blockSizes, i);
+      m_components[i]->applyProjectionJacobian(inblock, outblock);
+    }
+  }
+
+  void applyNormalConeProjectionJacobian(const ConstVectorRef &z,
+                                         MatrixRef Jout) const override {
+    for (std::size_t i = 0; i < m_components.size(); i++) {
+      ConstVectorRef inblock = blockVectorGetRow(z, m_blockSizes, i);
+      MatrixRef outblock = blockMatrixGetRow(Jout, m_blockSizes, i);
+      m_components[i]->applyNormalConeProjectionJacobian(inblock, outblock);
+    }
+  }
+
+  void computeActiveSet(const ConstVectorRef &z,
+                        Eigen::Ref<ActiveType> out) const override {
+    for (std::size_t i = 0; i < m_components.size(); i++) {
+      ConstVectorRef inblock = blockVectorGetRow(z, m_blockSizes, i);
+      decltype(out) outblock = blockVectorGetRow(out, m_blockSizes, i);
+      m_components[i]->computeActiveSet(inblock, outblock);
+    }
+  }
+
+  const std::vector<Eigen::Index> &blockSizes() const { return m_blockSizes; }
+
+private:
+  std::vector<Base *> m_components;
+  std::vector<Eigen::Index> m_blockSizes;
+};
+
+} // namespace nlp
+} // namespace proxsuite

--- a/src/constraints.cpp
+++ b/src/constraints.cpp
@@ -16,6 +16,8 @@ template struct PROXSUITE_NLP_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
     BoxConstraintTpl<context::Scalar>;
 template struct PROXSUITE_NLP_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
     NonsmoothPenaltyL1Tpl<context::Scalar>;
+template struct PROXSUITE_NLP_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ConstraintSetProductTpl<context::Scalar>;
 
 } // namespace nlp
 } // namespace proxsuite

--- a/tests/constraints.cpp
+++ b/tests/constraints.cpp
@@ -1,8 +1,5 @@
 #include "proxsuite-nlp/constraint-base.hpp"
-#include "proxsuite-nlp/modelling/constraints/equality-constraint.hpp"
-#include "proxsuite-nlp/modelling/constraints/negative-orthant.hpp"
-// #include "proxsuite-nlp/modelling/constraints/l1-penalty.hpp"
-
+#include "proxsuite-nlp/modelling/constraints.hpp"
 #include "proxsuite-nlp/modelling/spaces/vector-space.hpp"
 
 #include <fmt/core.h>
@@ -31,6 +28,26 @@ BOOST_AUTO_TEST_CASE(test_equality) {
   double m = eq_set.computeMoreauEnvelope(x1, zout);
   BOOST_TEST_CHECK(zout.isApprox(x1));
   BOOST_TEST_CHECK(m == (0.5 / mu * zout.squaredNorm()));
+}
+
+BOOST_AUTO_TEST_CASE(constraint_product_op) {
+  EqualityConstraintTpl<double> eq_op;
+  NegativeOrthantTpl<double> neg_op;
+  long n1 = 2, n2 = 3;
+  ConstraintSetProductTpl<double> op({&eq_op, &neg_op}, {n1, n2});
+
+  VectorXs z(n1 + n2);
+  z.setRandom();
+  z[4] = -0.14;
+  VectorXs zCopy = z;
+
+  fmt::print("z = {}\n", z.transpose());
+  op.normalConeProjection(zCopy, z);
+  fmt::print("zproj = {}\n", z.transpose());
+
+  neg_op.normalConeProjection(zCopy.tail(n2), zCopy.tail(n2));
+
+  BOOST_CHECK(z.isApprox(zCopy));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds the template class `ConstraintSetProductTpl` which allows the user to model products of constraint sets.

- [x] Exposed to Python
- [x] Add test to `tests/constraints.cpp`

We could also use this to simplify the backend code.