### PR TITLE
[prox-solver] deprecate getters for workspace and results in solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * `EqualityConstraint`/`NegativeOrthant` template classes changed to `EqualityConstraintTpl`/`NegativeOrthantTpl`
+* Deprecate getters `getWorkspace()` and `getResults()` in both C++ and Python ([#76](https://github.com/Simple-Robotics/proxsuite-nlp/pull/76))
+* Bump minimum version of eigenpy to 3.4.0 ([#76](https://github.com/Simple-Robotics/proxsuite-nlp/pull/76))
 
 ## [0.5.0] - 2024-04-23
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ add_project_dependency(Boost REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
 
 if(BUILD_PYTHON_INTERFACE)
   set(PYTHON_COMPONENTS Interpreter Development.Module NumPy Development)
-  add_project_dependency(eigenpy 3.2.0 REQUIRED PKG_CONFIG_REQUIRES "eigenpy >= 3.2.0")
+  add_project_dependency(eigenpy 3.4.0 REQUIRED PKG_CONFIG_REQUIRES "eigenpy >= 3.4.0")
 
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} -c "import platform; print(platform.python_implementation())"

--- a/bindings/python/include/proxsuite-nlp/python/deprecation-policy.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/deprecation-policy.hpp
@@ -1,0 +1,59 @@
+//
+// Copyright (C) 2024 LAAS-CNRS, INRIA
+//
+#pragma once
+
+namespace proxsuite {
+namespace nlp {
+namespace bp = boost::python;
+
+enum class DeprecationType { DEPRECATION, FUTURE };
+
+namespace detail {
+
+constexpr PyObject *deprecationTypeToPyObj(DeprecationType dep) {
+  switch (dep) {
+  case DeprecationType::DEPRECATION:
+    return PyExc_DeprecationWarning;
+  case DeprecationType::FUTURE:
+    return PyExc_FutureWarning;
+  }
+}
+
+} // namespace detail
+
+constexpr char defaultDeprecationMessage[] =
+    "This function or attribute has been marked as deprecated, and will be "
+    "removed in the "
+    "future.";
+
+/// @brief A Boost.Python call policy which triggers a Python warning on
+/// precall.
+template <DeprecationType deprecation_type = DeprecationType::DEPRECATION,
+          class BasePolicy = bp::default_call_policies>
+struct deprecation_warning_policy : BasePolicy {
+  using result_converter = typename BasePolicy::result_converter;
+  using argument_package = typename BasePolicy::argument_package;
+
+  deprecation_warning_policy(
+      const std::string &warning_msg = defaultDeprecationMessage)
+      : BasePolicy(), m_what(warning_msg) {}
+
+  std::string what() const { return m_what; }
+
+  const BasePolicy *derived() const {
+    return static_cast<const BasePolicy *>(this);
+  }
+
+  template <class ArgPackage> bool precall(const ArgPackage &args) const {
+    PyErr_WarnEx(detail::deprecationTypeToPyObj(deprecation_type),
+                 m_what.c_str(), 1);
+    return derived()->precall(args);
+  }
+
+private:
+  const std::string m_what;
+};
+
+} // namespace nlp
+} // namespace proxsuite

--- a/bindings/python/include/proxsuite-nlp/python/fwd.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/fwd.hpp
@@ -2,9 +2,6 @@
 
 #include <eigenpy/eigenpy.hpp>
 
-#ifdef byte
-#undef byte
-#endif
 #include "proxsuite-nlp/context.hpp"
 
 namespace proxsuite {

--- a/include/proxsuite-nlp/prox-solver.hpp
+++ b/include/proxsuite-nlp/prox-solver.hpp
@@ -148,7 +148,9 @@ public:
   ConvergenceFlag solve(const ConstVectorRef &x0,
                         const std::vector<VectorRef> &lams0);
 
+  PROXSUITE_NLP_DEPRECATED
   const Workspace &getWorkspace() const { return *workspace_; }
+  PROXSUITE_NLP_DEPRECATED
   const Results &getResults() const { return *results_; }
 
   /**


### PR DESCRIPTION
- deprecate `getWorkspace()` and `getResults()` in both C++ and Python 
- use eigenpy 3.4 unique_ptr support to expose to Python
- bump eigenpy minimum required version to 3.4