### PR TITLE
[API-break] Solver: store problem instance as a raw pointer, change solver ctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Changes to includes and tests for linesearch methods ([#81](https://github.com/Simple-Robotics/proxsuite-nlp/pull/81))
+* Solver: store problem instance as a raw pointer, change solver ctor ([#79](https://github.com/Simple-Robotics/proxsuite-nlp/pull/79))
 
 ## [0.6.0] - 2024-05-02
 

--- a/bindings/python/expose-problem.cpp
+++ b/bindings/python/expose-problem.cpp
@@ -10,8 +10,7 @@ void exposeProblem() {
   using context::Manifold;
   using context::Problem;
 
-  bp::class_<Problem, shared_ptr<Problem>>(
-      "Problem", "Problem definition class.", bp::no_init)
+  bp::class_<Problem>("Problem", "Problem definition class.", bp::no_init)
       .def(bp::init<shared_ptr<Manifold>, shared_ptr<context::Cost>,
                     const std::vector<Constraint> &>(
           (bp::arg("self"), bp::arg("space"), bp::arg("cost"),

--- a/bindings/python/expose-solver.cpp
+++ b/bindings/python/expose-solver.cpp
@@ -56,9 +56,8 @@ void exposeSolver() {
       .export_values();
 
   using LinesearchOptions = Linesearch<Scalar>::Options;
-  bp::class_<LinesearchOptions>(
-      "LinesearchOptions", "Linesearch options.",
-      bp::init<>(bp::args("self"), "Default constructor."))
+  bp::class_<LinesearchOptions>("LinesearchOptions", "Linesearch options.",
+                                bp::init<>(("self"_a), "Default constructor."))
       .def_readwrite("armijo_c1", &LinesearchOptions::armijo_c1)
       .def_readwrite("wolfe_c2", &LinesearchOptions::wolfe_c2)
       .def_readwrite(
@@ -91,14 +90,17 @@ void exposeSolver() {
       "Semi-smooth Newton-based solver for nonlinear optimization using a "
       "primal-dual method of multipliers. This solver works by approximately "
       "solving the proximal subproblems in the method of multipliers.",
-      bp::init<shared_ptr<Problem>, Scalar, Scalar, Scalar, VerboseLevel,
-               Scalar, Scalar, Scalar, Scalar, Scalar, LDLTChoice>(
-          (bp::arg("self"), bp::arg("problem"), bp::arg("tol") = 1e-6,
-           bp::arg("mu_init") = 1e-2, bp::arg("rho_init") = 0.,
-           bp::arg("verbose") = VerboseLevel::QUIET, bp::arg("mu_min") = 1e-9,
-           bp::arg("prim_alpha") = 0.1, bp::arg("prim_beta") = 0.9,
-           bp::arg("dual_alpha") = 1., bp::arg("dual_beta") = 1.,
-           bp::arg("ldlt_choice") = LDLTChoice::DENSE)))
+      bp::init<Problem &, Scalar, Scalar, Scalar, VerboseLevel, Scalar, Scalar,
+               Scalar, Scalar, Scalar, LDLTChoice>(
+          ("self"_a, "problem", "tol"_a = 1e-6, "mu_init"_a = 1e-2,
+           "rho_init"_a = 0., "verbose"_a = VerboseLevel::QUIET,
+           "mu_min"_a = 1e-9, "prim_alpha"_a = 0.1, "prim_beta"_a = 0.9,
+           "dual_alpha"_a = 1., "dual_beta"_a = 1.,
+           "ldlt_choice"_a = LDLTChoice::DENSE)))
+      .add_property("problem",
+                    bp::make_function(&ProxNLPSolver::problem,
+                                      bp::return_internal_reference<>()),
+                    "The general nonlinear program to solve.")
       .add_property("manifold",
                     bp::make_function(&ProxNLPSolver::manifold,
                                       bp::return_internal_reference<>()),
@@ -106,14 +108,14 @@ void exposeSolver() {
       .def_readwrite("hess_approx", &ProxNLPSolver::hess_approx)
       .def_readwrite("ls_strat", &ProxNLPSolver::ls_strat)
       .def("register_callback", &ProxNLPSolver::registerCallback,
-           bp::args("self", "cb"), "Add a callback to the solver.")
+           ("self"_a, "cb"), "Add a callback to the solver.")
       .def("clear_callbacks", &ProxNLPSolver::clearCallbacks,
-           "Clear callbacks.", bp::args("self"))
+           "Clear callbacks.", ("self"_a))
       .def_readwrite("verbose", &ProxNLPSolver::verbose,
                      "Solver verbose setting.")
       .def_readwrite("ldlt_choice", &ProxNLPSolver::ldlt_choice_,
                      "Use the BlockLDLT solver.")
-      .def("setup", &ProxNLPSolver::setup, bp::args("self"),
+      .def("setup", &ProxNLPSolver::setup, ("self"_a),
            "Initialize the solver workspace and results.")
       .def("getResults", &ProxNLPSolver::getResults, ("self"_a),
            deprecation_warning_policy<DeprecationType::DEPRECATION,
@@ -128,21 +130,19 @@ void exposeSolver() {
       .add_property("results", bp::make_getter(&ProxNLPSolver::results_,
                                                ReturnInternalStdUniquePtr{}))
       .def<solve_std_vec_ins_t>(
-          "solve", &ProxNLPSolver::solve, bp::args("self", "x0", "lams0"),
+          "solve", &ProxNLPSolver::solve, ("self"_a, "x0", "lams0"),
           "Run the solver (multiplier guesses given as a list).")
-      .def<solve_eig_vec_ins_t>("solve", &ProxNLPSolver::solve,
-                                (bp::arg("self"), bp::arg("x0"),
-                                 bp::arg("lams0") = context::VectorXs(0)),
-                                "Run the solver.")
-      .def("setPenalty", &ProxNLPSolver::setPenalty, bp::args("self", "mu"),
+      .def<solve_eig_vec_ins_t>(
+          "solve", &ProxNLPSolver::solve,
+          ("self"_a, "x0", "lams0"_a = context::VectorXs(0)), "Run the solver.")
+      .def("setPenalty", &ProxNLPSolver::setPenalty, ("self"_a, "mu"),
            "Set the augmented Lagrangian penalty parameter.")
       .def("setDualPenalty", &ProxNLPSolver::setDualPenalty,
-           bp::args("self", "gamma"),
+           ("self"_a, "gamma"),
            "Set the dual variable penalty for the linesearch merit "
            "function.")
       .def("setProxParameter", &ProxNLPSolver::setProxParameter,
-           bp::args("self", "rho"),
-           "Set the primal proximal penalty parameter.")
+           ("self"_a, "rho"), "Set the primal proximal penalty parameter.")
       .def_readwrite("mu_init", &ProxNLPSolver::mu_init_,
                      "Initial AL parameter value.")
       .def_readwrite("rho_init", &ProxNLPSolver::rho_init_,
@@ -188,7 +188,7 @@ void exposeSolver() {
   bp::class_<BCLParams>("BCLParams",
                         "Parameters for the bound-constrained Lagrangian (BCL) "
                         "penalty update strategy.",
-                        bp::init<>(bp::args("self")))
+                        bp::init<>(("self"_a)))
       .def_readwrite("prim_alpha", &BCLParams::prim_alpha)
       .def_readwrite("prim_beta", &BCLParams::prim_beta)
       .def_readwrite("dual_alpha", &BCLParams::dual_alpha)

--- a/examples/circle.cpp
+++ b/examples/circle.cpp
@@ -74,7 +74,7 @@ int main() {
   using CstrType = Problem::ConstraintObject;
   CstrType cstr1(residualCirclePtr, std::make_shared<Ineq_t>());
   std::vector<CstrType> cstrs{cstr1};
-  auto prob = std::make_shared<Problem>(space_, cost_fun, cstrs);
+  Problem prob(space_, cost_fun, cstrs);
 
   /// Test out merit functions
 
@@ -86,9 +86,9 @@ int main() {
   // PDAL FUNCTION
   fmt::print("  LAGR FUNC TEST\n");
 
-  Problem::VectorXs lams_data(prob->getTotalConstraintDim());
+  Problem::VectorXs lams_data(prob.getTotalConstraintDim());
   Problem::VectorOfRef lams;
-  helpers::allocateMultipliersOrResiduals(*prob, lams_data, lams);
+  helpers::allocateMultipliersOrResiduals(prob, lams_data, lams);
 
   fmt::print("Allocated {:d} multipliers | 1st mul = {}\n", lams.size(),
              lams[0]);

--- a/examples/equality-qp.cpp
+++ b/examples/equality-qp.cpp
@@ -26,6 +26,7 @@ using namespace proxsuite::nlp;
 using Problem = ProblemTpl<double>;
 using EqualityType = EqualityConstraintTpl<double>;
 using Constraint = ConstraintObjectTpl<double>;
+using SolverType = ProxNLPSolverTpl<double>;
 
 template <int N, int M = 1> int submain() {
   using Manifold = VectorSpaceTpl<double>;
@@ -55,11 +56,9 @@ template <int N, int M = 1> int submain() {
     constraints.emplace_back(res1, std::make_shared<EqualityType>());
   }
 
-  auto problem = std::make_shared<Problem>(space_, cost, constraints);
+  Problem problem(space_, cost, constraints);
 
-  using Solver_t = ProxNLPSolverTpl<double>;
-
-  Solver_t solver(problem);
+  SolverType solver(problem);
   solver.setPenalty(1e-4);
   solver.setProxParameter(1e-8);
   solver.setup();

--- a/examples/so2.cpp
+++ b/examples/so2.cpp
@@ -53,7 +53,7 @@ int main() {
   auto eq_set = std::make_shared<EqualityConstraintTpl<double>>();
   std::vector<Problem::ConstraintObject> cstrs;
   cstrs.emplace_back(resptr, eq_set);
-  auto prob = std::make_shared<Problem>(space_, cost_fun, cstrs);
+  Problem prob(space_, cost_fun, cstrs);
 
   /// Test out merit functions
 
@@ -67,7 +67,7 @@ int main() {
 
   Problem::VectorXs lams_data;
   Problem::VectorOfRef lams;
-  helpers::allocateMultipliersOrResiduals(*prob, lams_data, lams);
+  helpers::allocateMultipliersOrResiduals(prob, lams_data, lams);
 
   fmt::print("Allocated {:d} multipliers\n"
              "1st mul = {}\n",

--- a/examples/ur5-ik.cpp
+++ b/examples/ur5-ik.cpp
@@ -24,6 +24,7 @@ using Model = pin::ModelTpl<Scalar>;
 using Data = pin::DataTpl<Scalar>;
 using Space = MultibodyConfiguration<Scalar>;
 using Cost = CostFunctionBaseTpl<Scalar>;
+using Problem = ProblemTpl<Scalar>;
 const boost::filesystem::path URDF_PATH(EXAMPLE_ROBOT_DATA_MODEL_DIR);
 
 Model loadModel() {
@@ -93,7 +94,7 @@ int main() {
   cost->addComponent(cost1);
   cost->addComponent(cost2);
 
-  auto problem = std::make_shared<ProblemTpl<Scalar>>(space, cost);
+  Problem problem(space, cost);
 
   constexpr bool has_joint_lims = true;
   if (has_joint_lims) {
@@ -102,7 +103,7 @@ int main() {
     ConstraintObjectTpl<Scalar> cstrobj(
         std::make_shared<ManifoldDifferenceToPoint<Scalar>>(space, q0),
         box_cstr);
-    problem->addConstraint(cstrobj);
+    problem.addConstraint(cstrobj);
   }
 
   ProxNLPSolverTpl<Scalar> solver(problem, 1e-4, 0.01, 0.0,

--- a/include/proxsuite-nlp/problem-base.hpp
+++ b/include/proxsuite-nlp/problem-base.hpp
@@ -5,7 +5,6 @@
 #include "proxsuite-nlp/manifold-base.hpp"
 #include "proxsuite-nlp/cost-function.hpp"
 #include "proxsuite-nlp/constraint-base.hpp"
-#include "proxsuite-nlp/modelling/constraints/equality-constraint.hpp"
 
 namespace proxsuite {
 namespace nlp {

--- a/include/proxsuite-nlp/prox-solver.hpp
+++ b/include/proxsuite-nlp/prox-solver.hpp
@@ -105,18 +105,16 @@ public:
 
   //// Parameters for the inertia-correcting strategy.
 
-  const Scalar del_inc_k = 8.;
-  const Scalar del_inc_big = 100.;
-  const Scalar del_dec_k = 1. / 3.;
-
-  const Scalar DELTA_MIN = 1e-14; // Minimum nonzero regularization strength.
-  const Scalar DELTA_MAX = 1e6;   // Maximum regularization strength.
-  const Scalar DELTA_NONZERO_INIT = 1e-4;
+  Scalar del_inc_k = 8.;      //< Inertia corrector increase factor
+  Scalar del_inc_big = 100.;  //< Inertia corrector increase factor (big)
+  Scalar del_dec_k = 1. / 3.; //< Inertia corrector decrease factor
+  Scalar DELTA_MIN = 1e-14;   //< Minimum nonzero regularization strength.
+  Scalar DELTA_MAX = 1e6;     //< Maximum regularization strength.
+  Scalar DELTA_NONZERO_INIT = 1e-4;
   Scalar DELTA_INIT = 0.;
 
-  /// Solver maximum number of iterations.
-  std::size_t max_iters = 100;
-  std::size_t max_al_iters = 1000;
+  std::size_t max_iters = 100;     //< Solver maximum number of iterations.
+  std::size_t max_al_iters = 1000; //< Maximum outer (AL) iterations.
 
   /// Callbacks
   std::vector<CallbackPtr> callbacks_;

--- a/include/proxsuite-nlp/prox-solver.hpp
+++ b/include/proxsuite-nlp/prox-solver.hpp
@@ -49,8 +49,11 @@ public:
   using ConstraintSet = ConstraintSetBase<Scalar>;
   using ConstraintObject = ConstraintObjectTpl<Scalar>;
 
-  /// Manifold on which to optimize.
-  shared_ptr<Problem> problem_;
+protected:
+  /// General nonlinear program to solve.
+  Problem *problem_;
+
+public:
   /// Merit function.
   ALMeritFunctionTpl<Scalar> merit_fun;
   /// Proximal regularization penalty.
@@ -121,7 +124,7 @@ public:
   unique_ptr<Workspace> workspace_;
   unique_ptr<Results> results_;
 
-  ProxNLPSolverTpl(shared_ptr<Problem> prob, const Scalar tol = 1e-6,
+  ProxNLPSolverTpl(Problem &prob, const Scalar tol = 1e-6,
                    const Scalar mu_eq_init = 1e-2, const Scalar rho_init = 0.,
                    const VerboseLevel verbose = QUIET,
                    const Scalar mu_lower = 1e-9, const Scalar prim_alpha = 0.1,
@@ -129,6 +132,8 @@ public:
                    const Scalar dual_beta = 1.,
                    LDLTChoice ldlt_blocked = LDLTChoice::BUNCHKAUFMAN,
                    const LinesearchOptions ls_options = LinesearchOptions());
+
+  const Problem &problem() const { return *problem_; }
 
   const Manifold &manifold() const { return *problem_->manifold_; }
 

--- a/include/proxsuite-nlp/prox-solver.hxx
+++ b/include/proxsuite-nlp/prox-solver.hxx
@@ -13,13 +13,13 @@ namespace proxsuite {
 namespace nlp {
 template <typename Scalar>
 ProxNLPSolverTpl<Scalar>::ProxNLPSolverTpl(
-    shared_ptr<Problem> prob, const Scalar tol, const Scalar mu_init,
+    Problem &prob, const Scalar tol, const Scalar mu_init,
     const Scalar rho_init, const VerboseLevel verbose, const Scalar mu_lower,
     const Scalar prim_alpha, const Scalar prim_beta, const Scalar dual_alpha,
     const Scalar dual_beta, LDLTChoice ldlt_choice,
     const LinesearchOptions ls_options)
-    : problem_(prob), merit_fun(*problem_, pdal_beta_),
-      prox_penalty(prob->manifold_, manifold().neutral(),
+    : problem_(&prob), merit_fun(*problem_, pdal_beta_),
+      prox_penalty(prob.manifold_, manifold().neutral(),
                    rho_init *
                        MatrixXs::Identity(manifold().ndx(), manifold().ndx())),
       verbose(verbose), ldlt_choice_(ldlt_choice), rho_init_(rho_init),


### PR DESCRIPTION
This PR introduces an **API-breaking change**:

- the `Problem` class is no longer allocated on the heap and passed around as `shared_ptr`
- the `Problem` class is no longer exposed as shared_ptr in the Python bindings
- the solver class now stores a reference to the problem using a raw pointer `Problem *problem_`
- the `ProxNLPSolverTpl` constructor now uses a `Problem &` reference argument 