### PR TITLE
Add BFGS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `BfgsStrategy` to estimate (inverse) Hessian and use in Euclidian example ([#92](https://github.com/Simple-Robotics/proxsuite-nlp/pull/92))
+- Add `BfgsStrategy` to estimate (inverse) Hessian and use it in Euclidian example ([#92](https://github.com/Simple-Robotics/proxsuite-nlp/pull/92))
 
 ## [0.10.1] - 2025-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `BfgsStrategy` to estimate (inverse) Hessian and use in Euclidian example ([#92](https://github.com/Simple-Robotics/proxsuite-nlp/pull/92))
+
 ## [0.10.1] - 2025-01-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `prox-solver.hpp`: Add more alternatives to the `HessianApprox` enum  ([#92](https://github.com/Simple-Robotics/proxsuite-nlp/pull/92))
 - Add `BfgsStrategy` to estimate (inverse) Hessian and use it in Euclidian example ([#92](https://github.com/Simple-Robotics/proxsuite-nlp/pull/92))
 
 ## [0.10.1] - 2025-01-24

--- a/examples/ur5-ik.cpp
+++ b/examples/ur5-ik.cpp
@@ -108,12 +108,12 @@ int main() {
       BoxConstraintTpl<Scalar> box_cstr(model.lowerPositionLimit,
                                         model.upperPositionLimit);
       ConstraintObjectTpl<Scalar> cstrobj(
-          std::make_shared<ManifoldDifferenceToPoint<Scalar>>(PolyManifold{space},
-                                                              q0),
+          std::make_shared<ManifoldDifferenceToPoint<Scalar>>(
+              PolyManifold{space}, q0),
           box_cstr);
       problem.addConstraint(cstrobj);
     }
-    
+
     ProxNLPSolverTpl<Scalar> solver(problem, 1e-4, 0.01, 0.0,
                                     proxsuite::nlp::QUIET);
     solver.hess_approx = hess_approx;

--- a/include/proxsuite-nlp/bfgs-strategy.hpp
+++ b/include/proxsuite-nlp/bfgs-strategy.hpp
@@ -1,5 +1,5 @@
 /// @file
-/// @copyright Copyright (C) 2024 LAAS-CNRS, INRIA
+/// @copyright Copyright (C) 2024 INRIA
 #pragma once
 
 #include "proxsuite-nlp/fwd.hpp"
@@ -7,17 +7,17 @@
 namespace proxsuite {
 namespace nlp {
 
-enum BfgsType { Hessian, InverseHessian };
+enum BFGSType { Hessian, InverseHessian };
 
 // forward declaration
 template <typename Scalar, BfgsType BFGS_TYPE> struct BfgsUpdateImpl;
 
 template <typename Scalar, BfgsType BFGS_TYPE = BfgsType::InverseHessian>
-class BfgsStrategy {
+class BFGSStrategy {
   PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
 
 public:
-  BfgsStrategy(const int num_vars)
+  explicit BfgsStrategy(const int num_vars)
       : M(Eigen::MatrixXd::Identity(num_vars, num_vars)), is_init(false),
         is_psd(true), x_prev(VectorXs::Zero(num_vars)),
         g_prev(VectorXs::Zero(num_vars)), s(VectorXs::Zero(num_vars)),
@@ -45,7 +45,7 @@ public:
     PROXSUITE_NLP_NOMALLOC_BEGIN;
     s = x - x_prev;
     y = g - g_prev;
-    Scalar sy = s.dot(y);
+    const Scalar sy = s.dot(y);
 
     if (sy > 0) {
       BfgsUpdateImpl<Scalar, BFGS_TYPE>::update(*this, s, y);

--- a/include/proxsuite-nlp/bfgs-strategy.hpp
+++ b/include/proxsuite-nlp/bfgs-strategy.hpp
@@ -1,0 +1,115 @@
+/// @file
+/// @copyright Copyright (C) 2024 LAAS-CNRS, INRIA
+#pragma once
+
+#include "proxsuite-nlp/fwd.hpp"
+
+namespace proxsuite {
+namespace nlp {
+
+enum BfgsType { Hessian, InverseHessian };
+
+// forward declaration
+template <typename Scalar, BfgsType BFGS_TYPE> struct BfgsUpdateImpl;
+
+template <typename Scalar, BfgsType BFGS_TYPE = BfgsType::InverseHessian>
+class BfgsStrategy {
+  PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
+
+public:
+  BfgsStrategy(const int num_vars)
+      : M(Eigen::MatrixXd::Identity(num_vars, num_vars)), is_init(false),
+        is_psd(true), x_prev(VectorXs::Zero(num_vars)),
+        g_prev(VectorXs::Zero(num_vars)), s(VectorXs::Zero(num_vars)),
+        y(VectorXs::Zero(num_vars)),
+        xx_transpose(MatrixXs::Zero(num_vars, num_vars)),
+        xy_transpose(MatrixXs::Zero(num_vars, num_vars)),
+        V(MatrixXs::Zero(num_vars, num_vars)),
+        VMinv(MatrixXs::Zero(num_vars, num_vars)),
+        VMinvVt(MatrixXs::Zero(num_vars, num_vars)) {
+    x_prev = VectorXs::Zero(num_vars);
+    g_prev = VectorXs::Zero(num_vars);
+  }
+
+  void init(const ConstVectorRef &x0, const ConstVectorRef &g0) {
+    x_prev = x0;
+    g_prev = g0;
+    is_init = true;
+  }
+
+  void update(const ConstVectorRef &x, const ConstVectorRef &g) {
+    if (!is_init) {
+      init(x, g);
+      return;
+    }
+    PROXSUITE_NLP_NOMALLOC_BEGIN;
+    s = x - x_prev;
+    y = g - g_prev;
+    Scalar sy = s.dot(y);
+
+    if (sy > 0) {
+      BfgsUpdateImpl<Scalar, BFGS_TYPE>::update(*this, s, y);
+      V.noalias() = MatrixXs::Identity(s.size(), s.size()) - xy_transpose / sy;
+      VMinv.noalias() = V * M;
+      VMinvVt.noalias() = VMinv * V.transpose();
+      M = VMinvVt + xx_transpose / sy;
+      is_psd = true;
+    } else {
+      is_psd = false;
+      PROXSUITE_NLP_WARN("Skipping BFGS update as s^Ty <= 0");
+    }
+    x_prev = x;
+    g_prev = g;
+    PROXSUITE_NLP_NOMALLOC_END;
+  }
+
+public:
+  MatrixXs M; // (inverse of the) Hessian approximation
+  bool is_init;
+  bool is_psd;
+
+private:
+  friend struct BfgsUpdateImpl<Scalar, BFGS_TYPE>;
+  VectorXs x_prev; // previous iterate
+  VectorXs g_prev; // previous gradient
+  VectorXs s;      // delta iterate
+  VectorXs y;      // delta gradient
+  // temporary variables to avoid dynamic memory allocation
+  MatrixXs xx_transpose;
+  MatrixXs xy_transpose;
+  MatrixXs V;
+  MatrixXs VMinv;
+  MatrixXs VMinvVt;
+};
+
+// Specialization of update_impl method for BfgsType::InverseHessian
+// see Nocedal and Wright, Numerical Optimization, 2nd ed., p. 140, eqn 6.17
+// (BFGS update)
+template <typename Scalar>
+struct BfgsUpdateImpl<Scalar, BfgsType::InverseHessian> {
+  static void update(BfgsStrategy<Scalar, BfgsType::InverseHessian> &strategy,
+                     const typename BfgsStrategy<
+                         Scalar, BfgsType::InverseHessian>::ConstVectorRef &s,
+                     const typename BfgsStrategy<
+                         Scalar, BfgsType::InverseHessian>::ConstVectorRef &y) {
+    strategy.xx_transpose.noalias() = s * s.transpose();
+    strategy.xy_transpose.noalias() = s * y.transpose();
+  }
+};
+
+// Specialization of update_impl method for BfgsType::Hessian
+// see Nocedal and Wright, Numerical Optimization, 2nd ed., p. 139, eqn 6.13
+// (DFP update)
+template <typename Scalar> struct BfgsUpdateImpl<Scalar, BfgsType::Hessian> {
+  static void update(
+      BfgsStrategy<Scalar, BfgsType::Hessian> &strategy,
+      const typename BfgsStrategy<Scalar, BfgsType::Hessian>::ConstVectorRef &s,
+      const typename BfgsStrategy<Scalar, BfgsType::Hessian>::ConstVectorRef
+          &y) {
+    strategy.xx_transpose.noalias() = y * y.transpose();
+    strategy.xy_transpose.noalias() = y * s.transpose();
+  }
+};
+
+} // namespace nlp
+} // namespace proxsuite

--- a/include/proxsuite-nlp/bfgs-strategy.hpp
+++ b/include/proxsuite-nlp/bfgs-strategy.hpp
@@ -69,7 +69,7 @@ public:
       V.noalias() = MatrixXs::Identity(s.size(), s.size()) - xy_transpose / sy;
       VMinv.noalias() = V * hessian;
       VMinvVt.noalias() = VMinv * V.transpose();
-      hessian = VMinvVt + xx_transpose / sy;
+      hessian.noalias() = VMinvVt + xx_transpose / sy;
       is_psd = true;
     } else {
       is_psd = false;

--- a/include/proxsuite-nlp/bfgs-strategy.hpp
+++ b/include/proxsuite-nlp/bfgs-strategy.hpp
@@ -1,7 +1,6 @@
 /// @file
 /// @copyright Copyright (C) 2024-2025 INRIA
 #pragma once
-
 #include "proxsuite-nlp/fwd.hpp"
 
 namespace proxsuite {
@@ -18,14 +17,14 @@ class BFGSStrategy {
 
 public:
   BFGSStrategy()
-      : M(), is_init(false), is_psd(false), x_prev(), g_prev(), s(), y(),
+      : is_init(false), is_psd(false), x_prev(), g_prev(), s(), y(),
         xx_transpose(), xy_transpose(), V(), VMinv(), VMinvVt(),
         is_valid(false) {}
 
   explicit BFGSStrategy(const int num_vars)
-      : M(MatrixXs::Identity(num_vars, num_vars)), is_init(false), is_psd(true),
-        x_prev(VectorXs::Zero(num_vars)), g_prev(VectorXs::Zero(num_vars)),
-        s(VectorXs::Zero(num_vars)), y(VectorXs::Zero(num_vars)),
+      : is_init(false), is_psd(true), x_prev(VectorXs::Zero(num_vars)),
+        g_prev(VectorXs::Zero(num_vars)), s(VectorXs::Zero(num_vars)),
+        y(VectorXs::Zero(num_vars)),
         xx_transpose(MatrixXs::Zero(num_vars, num_vars)),
         xy_transpose(MatrixXs::Zero(num_vars, num_vars)),
         V(MatrixXs::Zero(num_vars, num_vars)),
@@ -60,10 +59,9 @@ public:
     if (sy > 0) {
       BFGSUpdateImpl<Scalar, BFGS_TYPE>::update(*this, s, y);
       V.noalias() = MatrixXs::Identity(s.size(), s.size()) - xy_transpose / sy;
-      VMinv.noalias() = V * M;
+      VMinv.noalias() = V * hessian;
       VMinvVt.noalias() = VMinv * V.transpose();
-      M = VMinvVt + xx_transpose / sy;
-      hessian = M;
+      hessian = VMinvVt + xx_transpose / sy;
       is_psd = true;
     } else {
       is_psd = false;
@@ -76,7 +74,6 @@ public:
   bool isValid() const { return is_valid; }
 
 public:
-  MatrixXs M; // (inverse of the) Hessian approximation
   bool is_init;
   bool is_psd;
 

--- a/include/proxsuite-nlp/bfgs-strategy.hpp
+++ b/include/proxsuite-nlp/bfgs-strategy.hpp
@@ -10,18 +10,17 @@ namespace nlp {
 enum BFGSType { Hessian, InverseHessian };
 
 // forward declaration
-template <typename Scalar, BfgsType BFGS_TYPE> struct BfgsUpdateImpl;
+template <typename Scalar, BFGSType BFGS_TYPE> struct BFGSUpdateImpl;
 
-template <typename Scalar, BfgsType BFGS_TYPE = BfgsType::InverseHessian>
+template <typename Scalar, BFGSType BFGS_TYPE = BFGSType::InverseHessian>
 class BFGSStrategy {
   PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
 
 public:
-  explicit BfgsStrategy(const int num_vars)
-      : M(Eigen::MatrixXd::Identity(num_vars, num_vars)), is_init(false),
-        is_psd(true), x_prev(VectorXs::Zero(num_vars)),
-        g_prev(VectorXs::Zero(num_vars)), s(VectorXs::Zero(num_vars)),
-        y(VectorXs::Zero(num_vars)),
+  explicit BFGSStrategy(const int num_vars)
+      : M(MatrixXs::Identity(num_vars, num_vars)), is_init(false), is_psd(true),
+        x_prev(VectorXs::Zero(num_vars)), g_prev(VectorXs::Zero(num_vars)),
+        s(VectorXs::Zero(num_vars)), y(VectorXs::Zero(num_vars)),
         xx_transpose(MatrixXs::Zero(num_vars, num_vars)),
         xy_transpose(MatrixXs::Zero(num_vars, num_vars)),
         V(MatrixXs::Zero(num_vars, num_vars)),
@@ -48,7 +47,7 @@ public:
     const Scalar sy = s.dot(y);
 
     if (sy > 0) {
-      BfgsUpdateImpl<Scalar, BFGS_TYPE>::update(*this, s, y);
+      BFGSUpdateImpl<Scalar, BFGS_TYPE>::update(*this, s, y);
       V.noalias() = MatrixXs::Identity(s.size(), s.size()) - xy_transpose / sy;
       VMinv.noalias() = V * M;
       VMinvVt.noalias() = VMinv * V.transpose();
@@ -69,7 +68,7 @@ public:
   bool is_psd;
 
 private:
-  friend struct BfgsUpdateImpl<Scalar, BFGS_TYPE>;
+  friend struct BFGSUpdateImpl<Scalar, BFGS_TYPE>;
   VectorXs x_prev; // previous iterate
   VectorXs g_prev; // previous gradient
   VectorXs s;      // delta iterate
@@ -82,29 +81,29 @@ private:
   MatrixXs VMinvVt;
 };
 
-// Specialization of update_impl method for BfgsType::InverseHessian
+// Specialization of update_impl method for BFGSType::InverseHessian
 // see Nocedal and Wright, Numerical Optimization, 2nd ed., p. 140, eqn 6.17
 // (BFGS update)
 template <typename Scalar>
-struct BfgsUpdateImpl<Scalar, BfgsType::InverseHessian> {
-  static void update(BfgsStrategy<Scalar, BfgsType::InverseHessian> &strategy,
-                     const typename BfgsStrategy<
-                         Scalar, BfgsType::InverseHessian>::ConstVectorRef &s,
-                     const typename BfgsStrategy<
-                         Scalar, BfgsType::InverseHessian>::ConstVectorRef &y) {
+struct BFGSUpdateImpl<Scalar, BFGSType::InverseHessian> {
+  static void update(BFGSStrategy<Scalar, BFGSType::InverseHessian> &strategy,
+                     const typename BFGSStrategy<
+                         Scalar, BFGSType::InverseHessian>::ConstVectorRef &s,
+                     const typename BFGSStrategy<
+                         Scalar, BFGSType::InverseHessian>::ConstVectorRef &y) {
     strategy.xx_transpose.noalias() = s * s.transpose();
     strategy.xy_transpose.noalias() = s * y.transpose();
   }
 };
 
-// Specialization of update_impl method for BfgsType::Hessian
+// Specialization of update_impl method for BFGSType::Hessian
 // see Nocedal and Wright, Numerical Optimization, 2nd ed., p. 139, eqn 6.13
 // (DFP update)
-template <typename Scalar> struct BfgsUpdateImpl<Scalar, BfgsType::Hessian> {
+template <typename Scalar> struct BFGSUpdateImpl<Scalar, BFGSType::Hessian> {
   static void update(
-      BfgsStrategy<Scalar, BfgsType::Hessian> &strategy,
-      const typename BfgsStrategy<Scalar, BfgsType::Hessian>::ConstVectorRef &s,
-      const typename BfgsStrategy<Scalar, BfgsType::Hessian>::ConstVectorRef
+      BFGSStrategy<Scalar, BFGSType::Hessian> &strategy,
+      const typename BFGSStrategy<Scalar, BFGSType::Hessian>::ConstVectorRef &s,
+      const typename BFGSStrategy<Scalar, BFGSType::Hessian>::ConstVectorRef
           &y) {
     strategy.xx_transpose.noalias() = y * y.transpose();
     strategy.xy_transpose.noalias() = y * s.transpose();

--- a/include/proxsuite-nlp/bfgs-strategy.hpp
+++ b/include/proxsuite-nlp/bfgs-strategy.hpp
@@ -46,7 +46,8 @@ public:
     is_init = true;
   }
 
-  void update(const ConstVectorRef &x, const ConstVectorRef &g) {
+  void update(const ConstVectorRef &x, const ConstVectorRef &g,
+              MatrixXs &hessian) {
     if (!is_init) {
       init(x, g);
       return;
@@ -62,6 +63,7 @@ public:
       VMinv.noalias() = V * M;
       VMinvVt.noalias() = VMinv * V.transpose();
       M = VMinvVt + xx_transpose / sy;
+      hessian = M;
       is_psd = true;
     } else {
       is_psd = false;
@@ -71,7 +73,6 @@ public:
     g_prev = g;
     PROXSUITE_NLP_NOMALLOC_END;
   }
-
   bool isValid() const { return is_valid; }
 
 public:

--- a/include/proxsuite-nlp/fmt-hessian-approx.hpp
+++ b/include/proxsuite-nlp/fmt-hessian-approx.hpp
@@ -1,5 +1,5 @@
 /// @file
-/// @copyright Copyright (C) 2024 INRIA
+/// @copyright Copyright (C) 2024-2025 INRIA
 #pragma once
 
 #include <fmt/ostream.h>

--- a/include/proxsuite-nlp/fmt-hessian-approx.hpp
+++ b/include/proxsuite-nlp/fmt-hessian-approx.hpp
@@ -1,0 +1,35 @@
+/// @file
+/// @copyright Copyright (C) 2024 INRIA
+#pragma once
+
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
+namespace fmt {
+template <> struct formatter<proxsuite::nlp::HessianApprox> {
+  template <typename ParseContext> constexpr auto parse(ParseContext &ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const proxsuite::nlp::HessianApprox &hessian_approx,
+              FormatContext &ctx) const {
+    std::string name;
+    switch (hessian_approx) {
+    case proxsuite::nlp::HessianApprox::EXACT:
+      name = "EXACT";
+      break;
+    case proxsuite::nlp::HessianApprox::GAUSS_NEWTON:
+      name = "GAUSS_NEWTON";
+      break;
+    case proxsuite::nlp::HessianApprox::BFGS:
+      name = "BFGS";
+      break;
+    case proxsuite::nlp::HessianApprox::IDENTITY:
+      name = "IDENTITY";
+      break;
+    }
+    return format_to(ctx.out(), "{}", name);
+  }
+};
+} // namespace fmt

--- a/include/proxsuite-nlp/prox-solver.hpp
+++ b/include/proxsuite-nlp/prox-solver.hpp
@@ -152,8 +152,8 @@ public:
       if (problem_->ndx() == problem_->nx()) {
         bfgs_strategy_ = std::make_unique<BFGS>(problem_->ndx());
       } else {
-        throw std::runtime_error(
-            "BFGS for hessian approximation currently only works for Euclidean manifolds.");
+        throw std::runtime_error("BFGS for hessian approximation currently "
+                                 "only works for Euclidean manifolds.");
       }
     }
   }

--- a/include/proxsuite-nlp/prox-solver.hpp
+++ b/include/proxsuite-nlp/prox-solver.hpp
@@ -153,6 +153,8 @@ public:
       if (problem_->ndx() == problem_->nx()) {
         BFGS valid_bfgs_strategy_ = BFGS(problem_->ndx());
         bfgs_strategy_ = std::move(valid_bfgs_strategy_);
+        //  set workspace hessian to identity matrix (init to zero in workspace)
+        workspace_->objective_hessian.setIdentity();
       } else {
         throw std::runtime_error("BFGS for hessian approximation currently "
                                  "only works for Euclidean manifolds.");

--- a/include/proxsuite-nlp/prox-solver.hpp
+++ b/include/proxsuite-nlp/prox-solver.hpp
@@ -73,7 +73,7 @@ public:
   LinesearchStrategy ls_strat = LinesearchStrategy::ARMIJO;
   MultiplierUpdateMode mul_update_mode = MultiplierUpdateMode::NEWTON;
 
-  unique_ptr<BFGS> bfgs_strategy_;
+  mutable BFGS bfgs_strategy_;
 
   /// linear algebra opts
   std::size_t max_refinement_steps_ = 5;
@@ -150,7 +150,8 @@ public:
     if (hess_approx == HessianApprox::BFGS) {
       // TODO: work on implementation of BFGS on manifolds
       if (problem_->ndx() == problem_->nx()) {
-        bfgs_strategy_ = std::make_unique<BFGS>(problem_->ndx());
+        BFGS valid_bfgs_strategy_ = BFGS(problem_->ndx());
+        bfgs_strategy_ = std::move(valid_bfgs_strategy_);
       } else {
         throw std::runtime_error("BFGS for hessian approximation currently "
                                  "only works for Euclidean manifolds.");

--- a/include/proxsuite-nlp/prox-solver.hpp
+++ b/include/proxsuite-nlp/prox-solver.hpp
@@ -10,6 +10,7 @@
 #include "proxsuite-nlp/helpers-base.hpp"
 #include "proxsuite-nlp/logger.hpp"
 #include "proxsuite-nlp/bcl-params.hpp"
+#include "proxsuite-nlp/bfgs-strategy.hpp"
 
 #include <boost/mpl/bool.hpp>
 
@@ -27,6 +28,10 @@ enum class HessianApprox {
   EXACT,
   /// Gauss-Newton (or rather SCQP) approximation
   GAUSS_NEWTON,
+  /// BFGS approximation
+  BFGS,
+  /// Identity
+  IDENTITY
 };
 
 enum InertiaFlag { INERTIA_OK = 0, INERTIA_BAD = 1, INERTIA_HAS_ZEROS = 2 };
@@ -48,6 +53,7 @@ public:
   using CallbackPtr = shared_ptr<helpers::base_callback<Scalar>>;
   using ConstraintSet = ConstraintSetTpl<Scalar>;
   using ConstraintObject = ConstraintObjectTpl<Scalar>;
+  using BFGS = BFGSStrategy<Scalar, BFGSType::Hessian>;
 
 protected:
   /// General nonlinear program to solve.
@@ -66,6 +72,8 @@ public:
   /// Linesearch strategy.
   LinesearchStrategy ls_strat = LinesearchStrategy::ARMIJO;
   MultiplierUpdateMode mul_update_mode = MultiplierUpdateMode::NEWTON;
+
+  unique_ptr<BFGS> bfgs_strategy_;
 
   /// linear algebra opts
   std::size_t max_refinement_steps_ = 5;
@@ -138,6 +146,16 @@ public:
   void setup() {
     workspace_ = std::make_unique<Workspace>(*problem_, ldlt_choice_);
     results_ = std::make_unique<Results>(*problem_);
+
+    if (hess_approx == HessianApprox::BFGS) {
+      // TODO: work on implementation of BFGS on manifolds
+      if (problem_->ndx() == problem_->nx()) {
+        bfgs_strategy_ = std::make_unique<BFGS>(problem_->ndx());
+      } else {
+        throw std::runtime_error(
+            "BFGS for hessian approximation currently only works for Euclidean manifolds.");
+      }
+    }
   }
 
   /**

--- a/include/proxsuite-nlp/prox-solver.hpp
+++ b/include/proxsuite-nlp/prox-solver.hpp
@@ -1,5 +1,6 @@
 /// @file
 /// @copyright Copyright (C) 2022 LAAS-CNRS, INRIA
+/// @copyright Copyright (C) 2024-2025 INRIA
 #pragma once
 
 #include "proxsuite-nlp/fwd.hpp"

--- a/include/proxsuite-nlp/prox-solver.hxx
+++ b/include/proxsuite-nlp/prox-solver.hxx
@@ -228,14 +228,21 @@ template <typename Scalar>
 void ProxNLPSolverTpl<Scalar>::computeProblemDerivatives(
     const ConstVectorRef &x, Workspace &workspace, boost::mpl::true_) const {
   this->computeProblemDerivatives(x, workspace, boost::mpl::false_());
-  if (hess_approx == HessianApprox::BFGS) {
+
+  switch (hess_approx) {
+  case HessianApprox::BFGS:
     bfgs_strategy_.update(x, workspace.objective_gradient);
     workspace.objective_hessian = bfgs_strategy_.M;
-  } else if (hess_approx == HessianApprox::IDENTITY) {
+    break;
+
+  case HessianApprox::IDENTITY:
     workspace.objective_hessian.setIdentity();
-  } else {
+    break;
+
+  default: // handle both EXACT and GAUSS_NEWTON
     problem_->computeHessians(x, workspace,
                               hess_approx == HessianApprox::EXACT);
+    break;
   }
 }
 

--- a/include/proxsuite-nlp/prox-solver.hxx
+++ b/include/proxsuite-nlp/prox-solver.hxx
@@ -234,7 +234,6 @@ void ProxNLPSolverTpl<Scalar>::computeProblemDerivatives(
   case HessianApprox::BFGS:
     bfgs_strategy_.update(x, workspace.objective_gradient,
                           workspace.objective_hessian);
-    // workspace.objective_hessian = bfgs_strategy_.M;
     break;
 
   case HessianApprox::IDENTITY:

--- a/include/proxsuite-nlp/prox-solver.hxx
+++ b/include/proxsuite-nlp/prox-solver.hxx
@@ -1,5 +1,6 @@
 /// @file
 /// @copyright Copyright (C) 2022 LAAS-CNRS, INRIA
+/// @copyright Copyright (C) 2024-2025 INRIA
 /// @brief     Implementations for the prox solver.
 #pragma once
 

--- a/include/proxsuite-nlp/prox-solver.hxx
+++ b/include/proxsuite-nlp/prox-solver.hxx
@@ -231,8 +231,9 @@ void ProxNLPSolverTpl<Scalar>::computeProblemDerivatives(
 
   switch (hess_approx) {
   case HessianApprox::BFGS:
-    bfgs_strategy_.update(x, workspace.objective_gradient);
-    workspace.objective_hessian = bfgs_strategy_.M;
+    bfgs_strategy_.update(x, workspace.objective_gradient,
+                          workspace.objective_hessian);
+    // workspace.objective_hessian = bfgs_strategy_.M;
     break;
 
   case HessianApprox::IDENTITY:

--- a/include/proxsuite-nlp/prox-solver.hxx
+++ b/include/proxsuite-nlp/prox-solver.hxx
@@ -228,7 +228,15 @@ template <typename Scalar>
 void ProxNLPSolverTpl<Scalar>::computeProblemDerivatives(
     const ConstVectorRef &x, Workspace &workspace, boost::mpl::true_) const {
   this->computeProblemDerivatives(x, workspace, boost::mpl::false_());
-  problem_->computeHessians(x, workspace, hess_approx == HessianApprox::EXACT);
+  if (hess_approx == HessianApprox::BFGS) {
+    bfgs_strategy_->update(x, workspace.objective_gradient);
+    workspace.objective_hessian = bfgs_strategy_->M;
+  } else if (hess_approx == HessianApprox::IDENTITY) {
+    workspace.objective_hessian.setIdentity();
+  } else {
+    problem_->computeHessians(x, workspace,
+                              hess_approx == HessianApprox::EXACT);
+  }
 }
 
 template <typename Scalar>

--- a/include/proxsuite-nlp/prox-solver.hxx
+++ b/include/proxsuite-nlp/prox-solver.hxx
@@ -229,8 +229,8 @@ void ProxNLPSolverTpl<Scalar>::computeProblemDerivatives(
     const ConstVectorRef &x, Workspace &workspace, boost::mpl::true_) const {
   this->computeProblemDerivatives(x, workspace, boost::mpl::false_());
   if (hess_approx == HessianApprox::BFGS) {
-    bfgs_strategy_->update(x, workspace.objective_gradient);
-    workspace.objective_hessian = bfgs_strategy_->M;
+    bfgs_strategy_.update(x, workspace.objective_gradient);
+    workspace.objective_hessian = bfgs_strategy_.M;
   } else if (hess_approx == HessianApprox::IDENTITY) {
     workspace.objective_hessian.setIdentity();
   } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,6 +153,7 @@ add_proxsuite_nlp_test(finite-diff)
 add_proxsuite_nlp_test(math)
 add_proxsuite_nlp_test(functions)
 add_proxsuite_nlp_test(linesearch)
+add_proxsuite_nlp_test(bfgs-strategy)
 add_proxsuite_nlp_test(manifolds)
 add_proxsuite_nlp_test(solver)
 

--- a/tests/bfgs-strategy.cpp
+++ b/tests/bfgs-strategy.cpp
@@ -1,0 +1,134 @@
+#include <boost/test/unit_test.hpp>
+#include "util.hpp"
+
+#include "proxsuite-nlp/bfgs-strategy.hpp"
+
+using namespace proxsuite::nlp;
+
+BOOST_AUTO_TEST_CASE(test_inverse_hessian_update) {
+  const long nx = 4;
+  using BfgsStrategy_t = BfgsStrategy<Scalar>; // default to InverseHessian
+  BfgsStrategy_t bfgs(nx);
+  VectorXs x0 = VectorXs::Random(nx);
+  VectorXs g0 = VectorXs::Random(nx);
+  bfgs.init(x0, g0);
+
+  VectorXs x;
+  VectorXs g;
+  VectorXs s;
+  VectorXs y;
+
+  bool is_psd = false;
+  while (!is_psd) {
+    x = VectorXs::Random(nx);
+    g = VectorXs::Random(nx);
+    s = x - x0;
+    y = g - g0;
+    if (s.dot(y) > 0) {
+      bfgs.update(x, g);
+      is_psd = bfgs.is_psd;
+    }
+  }
+
+  Scalar rho = 1. / s.dot(y);
+  MatrixXs H_inv_prev = MatrixXs::Identity(nx, nx);
+  MatrixXs H_inv = (MatrixXs::Identity(nx, nx) - rho * s * y.transpose()) *
+                       H_inv_prev *
+                       (MatrixXs::Identity(nx, nx) - rho * y * s.transpose()) +
+                   rho * s * s.transpose();
+  BOOST_TEST_CHECK(bfgs.M.isApprox(H_inv, 1e-6));
+}
+
+BOOST_AUTO_TEST_CASE(test_hessian_update) {
+  const long nx = 4;
+  using BfgsStrategy_t = BfgsStrategy<Scalar, BfgsType::Hessian>;
+  BfgsStrategy_t bfgs(nx);
+  VectorXs x0 = VectorXs::Random(nx);
+  VectorXs g0 = VectorXs::Random(nx);
+  bfgs.init(x0, g0);
+
+  VectorXs x;
+  VectorXs g;
+  VectorXs s;
+  VectorXs y;
+
+  bool is_psd = false;
+  while (!is_psd) {
+    x = VectorXs::Random(nx);
+    g = VectorXs::Random(nx);
+    s = x - x0;
+    y = g - g0;
+    if (s.dot(y) > 0) {
+      bfgs.update(x, g);
+      is_psd = bfgs.is_psd;
+    }
+  }
+
+  Scalar rho = 1. / s.dot(y);
+  MatrixXs H_prev = MatrixXs::Identity(nx, nx);
+  MatrixXs H = (MatrixXs::Identity(nx, nx) - rho * y * s.transpose()) * H_prev *
+                   (MatrixXs::Identity(nx, nx) - rho * s * y.transpose()) +
+               rho * y * y.transpose();
+  BOOST_TEST_CHECK(bfgs.M.isApprox(H, 1e-6));
+}
+
+BOOST_AUTO_TEST_CASE(test_bfgs_inverse_hessian) {
+  const long nx = 4;
+  using BfgsStrategy_t = BfgsStrategy<double, BfgsType::InverseHessian>;
+  BfgsStrategy_t bfgs(nx);
+
+  // random quadratic function with positive definite Hessian
+  Eigen::MatrixXd H = Eigen::MatrixXd::Random(nx, nx);
+  H = H.transpose() * H; // make it symmetric and positive definite
+  Eigen::MatrixXd H_inv = H.inverse();
+  Eigen::VectorXd b = Eigen::VectorXd::Random(nx);
+
+  Eigen::VectorXd x0 = Eigen::VectorXd::Random(nx);
+  Eigen::VectorXd g0 = H * x0 - b;
+  bfgs.init(x0, g0);
+
+  for (int i = 0; i < 1000; ++i) {
+    Eigen::VectorXd x = Eigen::VectorXd::Random(nx);
+    Eigen::VectorXd g = H * x - b; // gradient
+    bfgs.update(x, g);
+
+    Eigen::MatrixXd H_inv_approx = bfgs.M;
+    Eigen::MatrixXd H_inv_err = H_inv - H_inv_approx;
+    double err = H_inv_err.norm();
+    if (err < 1e-5) {
+      break;
+    }
+  }
+
+  BOOST_TEST_CHECK(bfgs.M.isApprox(H_inv, 1e-5));
+}
+
+BOOST_AUTO_TEST_CASE(test_bfgs_hessian) {
+  const long nx = 4;
+  using BfgsStrategy_t = BfgsStrategy<double, BfgsType::Hessian>;
+  BfgsStrategy_t bfgs(nx);
+
+  // random quadratic function with positive definite Hessian
+  Eigen::MatrixXd H = Eigen::MatrixXd::Random(nx, nx);
+  H = H.transpose() * H; // make it symmetric and positive definite
+  Eigen::VectorXd b = Eigen::VectorXd::Random(nx);
+
+  Eigen::VectorXd x0 = Eigen::VectorXd::Random(nx);
+  Eigen::VectorXd g0 = H * x0 - b;
+  bfgs.init(x0, g0);
+
+  for (int i = 0; i < 1000; ++i) {
+    Eigen::VectorXd x = Eigen::VectorXd::Random(nx);
+    Eigen::VectorXd g = H * x - b; // gradient
+    bfgs.update(x, g);
+
+    Eigen::MatrixXd H_approx = bfgs.M;
+    Eigen::MatrixXd H_err = H - H_approx;
+    double err = H_err.norm();
+    if (err < 1e-5) {
+      break;
+    }
+  }
+
+  BOOST_TEST_CHECK(bfgs.M.isApprox(H, 1e-5));
+}

--- a/tests/bfgs-strategy.cpp
+++ b/tests/bfgs-strategy.cpp
@@ -19,24 +19,24 @@ BOOST_AUTO_TEST_CASE(test_inverse_hessian_update) {
   VectorXs y;
 
   bool is_psd = false;
+  MatrixXs H;
   while (!is_psd) {
     x = VectorXs::Random(nx);
     g = VectorXs::Random(nx);
     s = x - x0;
     y = g - g0;
     if (s.dot(y) > 0) {
-      bfgs.update(x, g);
+      bfgs.update(x, g, H);
       is_psd = bfgs.is_psd;
     }
   }
-
   Scalar rho = 1. / s.dot(y);
   MatrixXs H_inv_prev = MatrixXs::Identity(nx, nx);
-  MatrixXs H_inv = (MatrixXs::Identity(nx, nx) - rho * s * y.transpose()) *
-                       H_inv_prev *
-                       (MatrixXs::Identity(nx, nx) - rho * y * s.transpose()) +
-                   rho * s * s.transpose();
-  BOOST_TEST_CHECK(bfgs.M.isApprox(H_inv, 1e-6));
+  MatrixXs H_inv_expected =
+      (MatrixXs::Identity(nx, nx) - rho * s * y.transpose()) * H_inv_prev *
+          (MatrixXs::Identity(nx, nx) - rho * y * s.transpose()) +
+      rho * s * s.transpose();
+  BOOST_TEST_CHECK(H.isApprox(H_inv_expected, 1e-6));
 }
 
 BOOST_AUTO_TEST_CASE(test_hessian_update) {
@@ -53,23 +53,25 @@ BOOST_AUTO_TEST_CASE(test_hessian_update) {
   VectorXs y;
 
   bool is_psd = false;
+  MatrixXs H;
   while (!is_psd) {
     x = VectorXs::Random(nx);
     g = VectorXs::Random(nx);
     s = x - x0;
     y = g - g0;
     if (s.dot(y) > 0) {
-      bfgs.update(x, g);
+      bfgs.update(x, g, H);
       is_psd = bfgs.is_psd;
     }
   }
 
   Scalar rho = 1. / s.dot(y);
   MatrixXs H_prev = MatrixXs::Identity(nx, nx);
-  MatrixXs H = (MatrixXs::Identity(nx, nx) - rho * y * s.transpose()) * H_prev *
-                   (MatrixXs::Identity(nx, nx) - rho * s * y.transpose()) +
-               rho * y * y.transpose();
-  BOOST_TEST_CHECK(bfgs.M.isApprox(H, 1e-6));
+  MatrixXs H_expected =
+      (MatrixXs::Identity(nx, nx) - rho * y * s.transpose()) * H_prev *
+          (MatrixXs::Identity(nx, nx) - rho * s * y.transpose()) +
+      rho * y * y.transpose();
+  BOOST_TEST_CHECK(H.isApprox(H_expected, 1e-6));
 }
 
 BOOST_AUTO_TEST_CASE(test_bfgs_inverse_hessian) {
@@ -87,12 +89,12 @@ BOOST_AUTO_TEST_CASE(test_bfgs_inverse_hessian) {
   Eigen::VectorXd g0 = H * x0 - b;
   bfgs.init(x0, g0);
 
+  MatrixXs H_inv_approx;
   for (int i = 0; i < 1000; ++i) {
     Eigen::VectorXd x = Eigen::VectorXd::Random(nx);
     Eigen::VectorXd g = H * x - b; // gradient
-    bfgs.update(x, g);
+    bfgs.update(x, g, H_inv_approx);
 
-    Eigen::MatrixXd H_inv_approx = bfgs.M;
     Eigen::MatrixXd H_inv_err = H_inv - H_inv_approx;
     double err = H_inv_err.norm();
     if (err < 1e-5) {
@@ -117,12 +119,12 @@ BOOST_AUTO_TEST_CASE(test_bfgs_hessian) {
   Eigen::VectorXd g0 = H * x0 - b;
   bfgs.init(x0, g0);
 
+  MatrixXs H_approx;
   for (int i = 0; i < 1000; ++i) {
     Eigen::VectorXd x = Eigen::VectorXd::Random(nx);
     Eigen::VectorXd g = H * x - b; // gradient
-    bfgs.update(x, g);
+    bfgs.update(x, g, H_approx);
 
-    Eigen::MatrixXd H_approx = bfgs.M;
     Eigen::MatrixXd H_err = H - H_approx;
     double err = H_err.norm();
     if (err < 1e-5) {

--- a/tests/bfgs-strategy.cpp
+++ b/tests/bfgs-strategy.cpp
@@ -7,8 +7,8 @@ using namespace proxsuite::nlp;
 
 BOOST_AUTO_TEST_CASE(test_inverse_hessian_update) {
   const long nx = 4;
-  using BfgsStrategy_t = BfgsStrategy<Scalar>; // default to InverseHessian
-  BfgsStrategy_t bfgs(nx);
+  using BFGSStrategy_t = BFGSStrategy<Scalar>; // default to InverseHessian
+  BFGSStrategy_t bfgs(nx);
   VectorXs x0 = VectorXs::Random(nx);
   VectorXs g0 = VectorXs::Random(nx);
   bfgs.init(x0, g0);
@@ -41,8 +41,8 @@ BOOST_AUTO_TEST_CASE(test_inverse_hessian_update) {
 
 BOOST_AUTO_TEST_CASE(test_hessian_update) {
   const long nx = 4;
-  using BfgsStrategy_t = BfgsStrategy<Scalar, BfgsType::Hessian>;
-  BfgsStrategy_t bfgs(nx);
+  using BFGSStrategy_t = BFGSStrategy<Scalar, BFGSType::Hessian>;
+  BFGSStrategy_t bfgs(nx);
   VectorXs x0 = VectorXs::Random(nx);
   VectorXs g0 = VectorXs::Random(nx);
   bfgs.init(x0, g0);
@@ -74,8 +74,8 @@ BOOST_AUTO_TEST_CASE(test_hessian_update) {
 
 BOOST_AUTO_TEST_CASE(test_bfgs_inverse_hessian) {
   const long nx = 4;
-  using BfgsStrategy_t = BfgsStrategy<double, BfgsType::InverseHessian>;
-  BfgsStrategy_t bfgs(nx);
+  using BFGSStrategy_t = BFGSStrategy<double, BFGSType::InverseHessian>;
+  BFGSStrategy_t bfgs(nx);
 
   // random quadratic function with positive definite Hessian
   Eigen::MatrixXd H = Eigen::MatrixXd::Random(nx, nx);
@@ -105,8 +105,8 @@ BOOST_AUTO_TEST_CASE(test_bfgs_inverse_hessian) {
 
 BOOST_AUTO_TEST_CASE(test_bfgs_hessian) {
   const long nx = 4;
-  using BfgsStrategy_t = BfgsStrategy<double, BfgsType::Hessian>;
-  BfgsStrategy_t bfgs(nx);
+  using BFGSStrategy_t = BFGSStrategy<double, BFGSType::Hessian>;
+  BFGSStrategy_t bfgs(nx);
 
   // random quadratic function with positive definite Hessian
   Eigen::MatrixXd H = Eigen::MatrixXd::Random(nx, nx);

--- a/tests/bfgs-strategy.cpp
+++ b/tests/bfgs-strategy.cpp
@@ -5,6 +5,8 @@
 
 using namespace proxsuite::nlp;
 
+// Tests the BFGS inverse Hessian update by verifying it follows the standard
+// formula.
 BOOST_AUTO_TEST_CASE(test_inverse_hessian_update) {
   const long nx = 4;
   using BFGSStrategy_t = BFGSStrategy<Scalar>; // default to InverseHessian
@@ -39,6 +41,8 @@ BOOST_AUTO_TEST_CASE(test_inverse_hessian_update) {
   BOOST_TEST_CHECK(H.isApprox(H_inv_expected, 1e-6));
 }
 
+// Tests the BFGS Hessian update by verifying it follows the standard DFP
+// formula.
 BOOST_AUTO_TEST_CASE(test_hessian_update) {
   const long nx = 4;
   using BFGSStrategy_t = BFGSStrategy<Scalar, BFGSType::Hessian>;
@@ -74,6 +78,8 @@ BOOST_AUTO_TEST_CASE(test_hessian_update) {
   BOOST_TEST_CHECK(H.isApprox(H_expected, 1e-6));
 }
 
+// Tests whether the BFGS inverse Hessian approximation converges to the true
+// inverse Hessian.
 BOOST_AUTO_TEST_CASE(test_bfgs_inverse_hessian) {
   const long nx = 4;
   using BFGSStrategy_t = BFGSStrategy<double, BFGSType::InverseHessian>;
@@ -105,6 +111,7 @@ BOOST_AUTO_TEST_CASE(test_bfgs_inverse_hessian) {
   BOOST_TEST_CHECK(bfgs.M.isApprox(H_inv, 1e-5));
 }
 
+// Tests whether the BFGS Hessian approximation converges to the true Hessian
 BOOST_AUTO_TEST_CASE(test_bfgs_hessian) {
   const long nx = 4;
   using BFGSStrategy_t = BFGSStrategy<double, BFGSType::Hessian>;

--- a/tests/bfgs-strategy.cpp
+++ b/tests/bfgs-strategy.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(test_inverse_hessian_update) {
   VectorXs y;
 
   bool is_psd = false;
-  MatrixXs H;
+  MatrixXs H = MatrixXs::Identity(nx, nx);
   while (!is_psd) {
     x = VectorXs::Random(nx);
     g = VectorXs::Random(nx);
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(test_hessian_update) {
   VectorXs y;
 
   bool is_psd = false;
-  MatrixXs H;
+  MatrixXs H = MatrixXs::Identity(nx, nx);
   while (!is_psd) {
     x = VectorXs::Random(nx);
     g = VectorXs::Random(nx);
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(test_bfgs_inverse_hessian) {
   Eigen::VectorXd g0 = H * x0 - b;
   bfgs.init(x0, g0);
 
-  MatrixXs H_inv_approx;
+  MatrixXs H_inv_approx = MatrixXs::Identity(nx, nx);
   for (int i = 0; i < 1000; ++i) {
     Eigen::VectorXd x = Eigen::VectorXd::Random(nx);
     Eigen::VectorXd g = H * x - b; // gradient
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(test_bfgs_inverse_hessian) {
     }
   }
 
-  BOOST_TEST_CHECK(bfgs.M.isApprox(H_inv, 1e-5));
+  BOOST_TEST_CHECK(H_inv_approx.isApprox(H_inv, 1e-5));
 }
 
 // Tests whether the BFGS Hessian approximation converges to the true Hessian
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(test_bfgs_hessian) {
   Eigen::VectorXd g0 = H * x0 - b;
   bfgs.init(x0, g0);
 
-  MatrixXs H_approx;
+  MatrixXs H_approx = MatrixXs::Identity(nx, nx);
   for (int i = 0; i < 1000; ++i) {
     Eigen::VectorXd x = Eigen::VectorXd::Random(nx);
     Eigen::VectorXd g = H * x - b; // gradient
@@ -139,5 +139,5 @@ BOOST_AUTO_TEST_CASE(test_bfgs_hessian) {
     }
   }
 
-  BOOST_TEST_CHECK(bfgs.M.isApprox(H, 1e-5));
+  BOOST_TEST_CHECK(H_approx.isApprox(H, 1e-5));
 }


### PR DESCRIPTION
Start of work to add the Broyden–Fletcher–Goldfarb–Shanno algorithm. For now, it is a class that estimates an (inverse) Hessian from iterates and the corresponding gradients at these iterates. An optimizer can be built around it. 

It implements the BFGS update rule (eqn 6.17 p. 140) to estimate the inverse Hessian and the DFP update rule (eqn 6.13 p.139) from Nocedal and Wright, Numerical Optimization, 2nd edition, which have a similar structure.