### PR TITLE
Manage xyz::polymorphic by deep copy in Python binding

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,7 @@ jobs:
       shell: bash -el {0}
       run: |
         conda build -c conda-forge \
-          --error-overlinking \
+          --no-error-overlinking \
           --py ${{ matrix.python-version }} \
           --numpy ${{ matrix.numpy-version }} \
           packaging/conda/proxsuite-nlp-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add the `polymorphic_cxx14.hpp` header from [jbcoe/value_types](https://github.com/jbcoe/value_types/blob/main/polymorphic_cxx14.h), [#90](https://github.com/Simple-Robotics/proxsuite-nlp/pull/90)
+* **Python:** add conversions (for values, versions) for the `polymorphic<T,A>` types in new `<proxsuite-nlp/python/polymorphic.hpp>` header
+* **Python:** add `PolymorphicVisitor` visitor and `register_polymorphic_to_python<T>()` template function to register conversions from/to the `polymorphic<T, A>` type
 
 ### Changed
 
 * Change from `shared_ptr<T>` to `polymorphic<T>` for manifolds and constraint sets
-* Remove use of `std::make_shared` for manifolds in examples [#90](https://github.com/Simple-Robotics/proxsuite-nlp/pull/90)
-* Changed ctor of `ProblemTpl` to template which takes the manifold
+* Remove use of `std::make_shared` for manifolds in examples [#90](https://github.com/Simple-Robotics/proxsuite-nlp/pull/90), instead plass pain types
+* `ConstraintObjectTpl` now holds the constraint set through a `polymorphic<ConstraintSet>`
+* Changed ctors of `ProblemTpl` and `CostAbstractTpl` to template which takes the concrete manifold type
+* **Python:** pull all wrapper classes (inheriting from `bp::wrapper<U>`) out of the `aligator::python::internal` namespace
+* **Python:** fix abstract classes exposed as subclasses of `bp::wrapper<U>` not registering their owning `PyObject*` properly
 
 ## [0.7.0] - 2024-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Add the `polymorphic_cxx14.hpp` header from [jbcoe/value_types](https://github.com/jbcoe/value_types/blob/main/polymorphic_cxx14.h), [#90](https://github.com/Simple-Robotics/proxsuite-nlp/pull/90)
+
+### Changed
+
+* Change from `shared_ptr<T>` to `polymorphic<T>` for manifolds and constraint sets
+* Remove use of `std::make_shared` for manifolds in examples [#90](https://github.com/Simple-Robotics/proxsuite-nlp/pull/90)
+* Changed ctor of `ProblemTpl` to template which takes the manifold
+
 ## [0.7.0] - 2024-05-14
 
 ### Changed

--- a/bindings/python/expose-cartesian-product.cpp
+++ b/bindings/python/expose-cartesian-product.cpp
@@ -37,10 +37,9 @@ void exposeCartesianProduct() {
       bp::no_init)
       .def(bp::init<>("self"_a))
       .def(bp::init<const std::vector<PolymorphicManifold> &>(
-          ("self"_a, "spaces"))[with_custodian_and_ward_list_content<1, 2>()])
+          ("self"_a, "spaces")))
       .def(bp::init<PolymorphicManifold, PolymorphicManifold>(
-          ("self"_a, "left", "right"))[bp::with_custodian_and_ward<
-          1, 2, bp::with_custodian_and_ward<1, 3>>()])
+          ("self"_a, "left", "right")))
       .def(
           "getComponent",
           +[](CartesianProduct const &m, std::size_t i) -> const Manifold & {
@@ -53,8 +52,7 @@ void exposeCartesianProduct() {
           bp::return_internal_reference<>(), ("self"_a, "i"),
           "Get the i-th component of the Cartesian product.")
       .def("addComponent", &CartesianProduct::addComponent<PolymorphicManifold>,
-           ("self"_a, "c"), bp::with_custodian_and_ward<1, 2>(),
-           "Add a component to the Cartesian product.")
+           ("self"_a, "c"), "Add a component to the Cartesian product.")
       .add_property("num_components", &CartesianProduct::numComponents,
                     "Get the number of components in the Cartesian product.")
       .def(

--- a/bindings/python/expose-cartesian-product.cpp
+++ b/bindings/python/expose-cartesian-product.cpp
@@ -31,6 +31,7 @@ void exposeCartesianProduct() {
   using MutSplitSig =
       std::vector<VectorRef> (CartesianProduct::*)(VectorRef) const;
 
+  bp::implicitly_convertible<CartesianProduct, PolymorphicManifold>();
   bp::class_<CartesianProduct, bp::bases<Manifold>,
              shared_ptr<CartesianProduct>>(
       "CartesianProduct", "Cartesian product of two or more manifolds.",

--- a/bindings/python/expose-cartesian-product.cpp
+++ b/bindings/python/expose-cartesian-product.cpp
@@ -37,9 +37,10 @@ void exposeCartesianProduct() {
       bp::no_init)
       .def(bp::init<>("self"_a))
       .def(bp::init<const std::vector<PolymorphicManifold> &>(
-          ("self"_a, "spaces")))
+          ("self"_a, "spaces"))[bp::with_custodian_and_ward<1, 2>()])
       .def(bp::init<PolymorphicManifold, PolymorphicManifold>(
-          ("self"_a, "left", "right")))
+          ("self"_a, "left", "right"))[bp::with_custodian_and_ward<
+          1, 2, bp::with_custodian_and_ward<1, 3>>()])
       .def(
           "getComponent",
           +[](CartesianProduct const &m, std::size_t i) -> const Manifold & {
@@ -52,7 +53,8 @@ void exposeCartesianProduct() {
           bp::return_internal_reference<>(), ("self"_a, "i"),
           "Get the i-th component of the Cartesian product.")
       .def("addComponent", &CartesianProduct::addComponent<PolymorphicManifold>,
-           ("self"_a, "c"), "Add a component to the Cartesian product.")
+           ("self"_a, "c"), bp::with_custodian_and_ward<1, 2>(),
+           "Add a component to the Cartesian product.")
       .add_property("num_components", &CartesianProduct::numComponents,
                     "Get the number of components in the Cartesian product.")
       .def(

--- a/bindings/python/expose-cartesian-product.cpp
+++ b/bindings/python/expose-cartesian-product.cpp
@@ -83,7 +83,11 @@ void exposeCartesianProduct() {
            "component.")
       .def("merge_vector", &CartesianProduct::merge_vector, ("self"_a, "vs"),
            "Define a tangent vector on the manifold by merging vectors from "
-           "each component.");
+           "each component.")
+      .def(
+          "__mul__", +[](const CartesianProduct &a, const CartesianProduct &b) {
+            return a * b;
+          });
 }
 
 } // namespace python

--- a/bindings/python/expose-cartesian-product.cpp
+++ b/bindings/python/expose-cartesian-product.cpp
@@ -32,8 +32,7 @@ void exposeCartesianProduct() {
       std::vector<VectorRef> (CartesianProduct::*)(VectorRef) const;
 
   bp::implicitly_convertible<CartesianProduct, PolymorphicManifold>();
-  bp::class_<CartesianProduct, bp::bases<Manifold>,
-             shared_ptr<CartesianProduct>>(
+  bp::class_<CartesianProduct, bp::bases<Manifold>>(
       "CartesianProduct", "Cartesian product of two or more manifolds.",
       bp::no_init)
       .def(bp::init<>("self"_a))

--- a/bindings/python/expose-cartesian-product.cpp
+++ b/bindings/python/expose-cartesian-product.cpp
@@ -1,6 +1,7 @@
 #include "proxsuite-nlp/modelling/spaces/cartesian-product.hpp"
 
 #include "proxsuite-nlp/python/fwd.hpp"
+#include "proxsuite-nlp/python/polymorphic.hpp"
 
 namespace proxsuite {
 namespace nlp {
@@ -31,7 +32,6 @@ void exposeCartesianProduct() {
   using MutSplitSig =
       std::vector<VectorRef> (CartesianProduct::*)(VectorRef) const;
 
-  bp::implicitly_convertible<CartesianProduct, PolymorphicManifold>();
   bp::class_<CartesianProduct, bp::bases<Manifold>>(
       "CartesianProduct", "Cartesian product of two or more manifolds.",
       bp::no_init)
@@ -84,9 +84,9 @@ void exposeCartesianProduct() {
            "Define a tangent vector on the manifold by merging vectors from "
            "each component.")
       .def(
-          "__mul__", +[](const CartesianProduct &a, const CartesianProduct &b) {
-            return a * b;
-          });
+          "__mul__", +[](const CartesianProduct &a,
+                         const CartesianProduct &b) { return a * b; })
+      .def(PolymorphicVisitor<PolymorphicManifold>());
 }
 
 } // namespace python

--- a/bindings/python/expose-cartesian-product.cpp
+++ b/bindings/python/expose-cartesian-product.cpp
@@ -37,7 +37,7 @@ void exposeCartesianProduct() {
       bp::no_init)
       .def(bp::init<>("self"_a))
       .def(bp::init<const std::vector<PolymorphicManifold> &>(
-          ("self"_a, "spaces"))[bp::with_custodian_and_ward<1, 2>()])
+          ("self"_a, "spaces"))[with_custodian_and_ward_list_content<1, 2>()])
       .def(bp::init<PolymorphicManifold, PolymorphicManifold>(
           ("self"_a, "left", "right"))[bp::with_custodian_and_ward<
           1, 2, bp::with_custodian_and_ward<1, 3>>()])

--- a/bindings/python/expose-cartesian-product.cpp
+++ b/bindings/python/expose-cartesian-product.cpp
@@ -34,10 +34,12 @@ void exposeCartesianProduct() {
   bp::class_<CartesianProduct, bp::bases<Manifold>,
              shared_ptr<CartesianProduct>>(
       "CartesianProduct", "Cartesian product of two or more manifolds.",
-      bp::init<const std::vector<PolymorphicManifold> &>(
-          bp::args("self", "spaces")))
+      bp::no_init)
+      .def(bp::init<>("self"_a))
+      .def(bp::init<const std::vector<PolymorphicManifold> &>(
+          ("self"_a, "spaces")))
       .def(bp::init<PolymorphicManifold, PolymorphicManifold>(
-          bp::args("self", "left", "right")))
+          ("self"_a, "left", "right")))
       .def(
           "getComponent",
           +[](CartesianProduct const &m, std::size_t i) -> const Manifold & {
@@ -47,14 +49,10 @@ void exposeCartesianProduct() {
             }
             return m.getComponent(i);
           },
-          bp::return_internal_reference<>(), bp::args("self", "i"),
+          bp::return_internal_reference<>(), ("self"_a, "i"),
           "Get the i-th component of the Cartesian product.")
-      .def(
-          "addComponent",
-          +[](CartesianProduct &m, PolymorphicManifold const &p) {
-            m.addComponent(p);
-          },
-          bp::args("self", "c"), "Add a component to the Cartesian product.")
+      .def("addComponent", &CartesianProduct::addComponent<PolymorphicManifold>,
+           ("self"_a, "c"), "Add a component to the Cartesian product.")
       .add_property("num_components", &CartesianProduct::numComponents,
                     "Get the number of components in the Cartesian product.")
       .def(
@@ -62,9 +60,9 @@ void exposeCartesianProduct() {
           +[](CartesianProduct const &m, const ConstVectorRef &x) {
             return copy_vec_constref(m.split(x));
           },
-          bp::args("self", "x"), split_doc.c_str())
+          ("self"_a, "x"), split_doc.c_str())
       .def<MutSplitSig>(
-          "split", &CartesianProduct::split, bp::args("self", "x"),
+          "split", &CartesianProduct::split, ("self"_a, "x"),
           (split_doc +
            " This returns a list of mutable references to each component.")
               .c_str())
@@ -73,18 +71,16 @@ void exposeCartesianProduct() {
           +[](CartesianProduct const &m, const ConstVectorRef &x) {
             return copy_vec_constref(m.split_vector(x));
           },
-          bp::args("self", "v"), split_vec_doc.c_str())
+          ("self"_a, "v"), split_vec_doc.c_str())
       .def<MutSplitSig>(
-          "split_vector", &CartesianProduct::split_vector,
-          bp::args("self", "v"),
+          "split_vector", &CartesianProduct::split_vector, ("self"_a, "v"),
           (split_vec_doc +
            " This returns a list of mutable references to each component.")
               .c_str())
-      .def("merge", &CartesianProduct::merge, bp::args("self", "xs"),
+      .def("merge", &CartesianProduct::merge, ("self"_a, "xs"),
            "Define a point on the manifold by merging points from each "
            "component.")
-      .def("merge_vector", &CartesianProduct::merge_vector,
-           bp::args("self", "vs"),
+      .def("merge_vector", &CartesianProduct::merge_vector, ("self"_a, "vs"),
            "Define a tangent vector on the manifold by merging vectors from "
            "each component.");
 }

--- a/bindings/python/expose-constraint.cpp
+++ b/bindings/python/expose-constraint.cpp
@@ -1,7 +1,7 @@
 /// @copyright Copyright (C) 2022 LAAS-CNRS, INRIA
-#include "proxsuite-nlp/python/polymorphic.hpp"
-
 #include "proxsuite-nlp/modelling/constraints.hpp"
+
+#include "proxsuite-nlp/python/polymorphic.hpp"
 
 #include <eigenpy/std-vector.hpp>
 
@@ -18,7 +18,6 @@ using eigenpy::StdVectorPythonVisitor;
 using L1Penalty = NonsmoothPenaltyL1Tpl<Scalar>;
 using ConstraintSetProduct = ConstraintSetProductTpl<Scalar>;
 using BoxConstraint = BoxConstraintTpl<Scalar>;
-using xyz::polymorphic;
 
 template <typename T>
 auto exposeSpecificConstraintSet(const char *name, const char *docstring) {

--- a/bindings/python/expose-constraint.cpp
+++ b/bindings/python/expose-constraint.cpp
@@ -5,6 +5,8 @@
 
 #include <eigenpy/std-vector.hpp>
 
+#include <vector>
+
 namespace proxsuite {
 namespace nlp {
 namespace python {
@@ -136,6 +138,11 @@ static void exposeConstraintTypes() {
                     bp::make_function(&ConstraintSetProduct::blockSizes,
                                       bp::return_internal_reference<>()),
                     "Dimensions of each component of the cartesian product.");
+
+  StdVectorPythonVisitor<std::vector<polymorphic<ConstraintSet>>>::expose(
+      "StdVec_ConstraintObject",
+      eigenpy::details::overload_base_get_item_for_std_vector<
+          std::vector<polymorphic<ConstraintSet>>>());
 }
 
 } // namespace python

--- a/bindings/python/expose-constraint.cpp
+++ b/bindings/python/expose-constraint.cpp
@@ -128,7 +128,7 @@ static void exposeConstraintTypes() {
       .def(bp::init<std::vector<polymorphic<ConstraintSet>>,
                     std::vector<Eigen::Index>>(
           ("self"_a, "components",
-           "blockSizes"))[bp::with_custodian_and_ward<1, 2>()])
+           "blockSizes"))[with_custodian_and_ward_list_content<1, 2>()])
       .add_property("components",
                     bp::make_function(&ConstraintSetProduct::components,
                                       bp::return_internal_reference<>()))

--- a/bindings/python/expose-constraint.cpp
+++ b/bindings/python/expose-constraint.cpp
@@ -82,8 +82,7 @@ void exposeConstraints() {
   bp::class_<Constraint>(
       "ConstraintObject", "Packs a constraint set together with a function.",
       bp::init<shared_ptr<C2Function>, const polymorphic<ConstraintSet> &>(
-          ("self"_a, "func",
-           "constraint_set"))[bp::with_custodian_and_ward<1, 3>()])
+          ("self"_a, "func", "constraint_set")))
       .add_property("nr", &Constraint::nr, "Constraint dimension.")
       .def_readonly("func", &Constraint::func_, "Underlying function.")
       .def_readonly("set", &Constraint::set_, "Constraint set.");
@@ -129,8 +128,7 @@ static void exposeConstraintTypes() {
       "ConstraintSetProduct", "Cartesian product of constraint sets.")
       .def(bp::init<std::vector<polymorphic<ConstraintSet>>,
                     std::vector<Eigen::Index>>(
-          ("self"_a, "components",
-           "blockSizes"))[with_custodian_and_ward_list_content<1, 2>()])
+          ("self"_a, "components", "blockSizes")))
       .add_property("components",
                     bp::make_function(&ConstraintSetProduct::components,
                                       bp::return_internal_reference<>()))

--- a/bindings/python/expose-constraint.cpp
+++ b/bindings/python/expose-constraint.cpp
@@ -21,8 +21,8 @@ using BoxConstraint = BoxConstraintTpl<Scalar>;
 
 template <typename T>
 auto exposeSpecificConstraintSet(const char *name, const char *docstring) {
-  bp::implicitly_convertible<T, polymorphic<ConstraintSet>>();
-  return bp::class_<T, bp::bases<ConstraintSet>>(name, docstring, bp::no_init);
+  return bp::class_<T, bp::bases<ConstraintSet>>(name, docstring, bp::no_init)
+      .def(PolymorphicVisitor<polymorphic<ConstraintSet>>());
 }
 
 template <typename ConstraintType>

--- a/bindings/python/expose-constraint.cpp
+++ b/bindings/python/expose-constraint.cpp
@@ -1,5 +1,5 @@
 /// @copyright Copyright (C) 2022 LAAS-CNRS, INRIA
-#include "proxsuite-nlp/python/fwd.hpp"
+#include "proxsuite-nlp/python/polymorphic.hpp"
 
 #include "proxsuite-nlp/modelling/constraints.hpp"
 
@@ -18,16 +18,17 @@ using eigenpy::StdVectorPythonVisitor;
 using L1Penalty = NonsmoothPenaltyL1Tpl<Scalar>;
 using ConstraintSetProduct = ConstraintSetProductTpl<Scalar>;
 using BoxConstraint = BoxConstraintTpl<Scalar>;
+using xyz::polymorphic;
 
 template <typename T>
 auto exposeSpecificConstraintSet(const char *name, const char *docstring) {
-  return bp::class_<T, bp::bases<context::ConstraintSet>>(name, docstring,
-                                                          bp::no_init);
+  bp::implicitly_convertible<T, polymorphic<ConstraintSet>>();
+  return bp::class_<T, bp::bases<ConstraintSet>>(name, docstring, bp::no_init);
 }
 
-template <typename T>
+template <typename ConstraintType>
 context::Constraint make_constraint(const shared_ptr<context::C2Function> &f) {
-  return context::Constraint(f, std::make_shared<T>());
+  return context::Constraint(f, ConstraintType{});
 }
 
 static void exposeConstraintTypes();
@@ -35,15 +36,14 @@ static void exposeConstraintTypes();
 /// @todo Expose properly using pure_virtual, to allow overriding from Python
 void exposeConstraints() {
 
-  bp::register_ptr_to_python<shared_ptr<ConstraintSet>>();
+  register_polymorphic_to_python<polymorphic<ConstraintSet>>();
   bp::class_<ConstraintSet, boost::noncopyable>(
       "ConstraintSetBase",
       "Base class for constraint sets or nonsmooth penalties.", bp::no_init)
-      .def("evaluate", &ConstraintSet::evaluate, bp::args("self", "z"),
+      .def("evaluate", &ConstraintSet::evaluate, ("self"_a, "z"),
            "Evaluate the constraint indicator function or nonsmooth penalty "
            "on the projection/prox map of :math:`z`.")
-      .def("projection", &ConstraintSet::projection,
-           bp::args("self", "z", "zout"))
+      .def("projection", &ConstraintSet::projection, ("self"_a, "z", "zout"))
       .def(
           "projection",
           +[](const ConstraintSet &c, const ConstVectorRef &z) {
@@ -51,9 +51,9 @@ void exposeConstraints() {
             c.projection(z, zout);
             return zout;
           },
-          bp::args("self", "z"))
+          ("self"_a, "z"))
       .def("normalConeProjection", &ConstraintSet::normalConeProjection,
-           bp::args("self", "z", "zout"))
+           ("self"_a, "z", "zout"))
       .def(
           "normalConeProjection",
           +[](const ConstraintSet &c, const ConstVectorRef &z) {
@@ -61,27 +61,27 @@ void exposeConstraints() {
             c.normalConeProjection(z, zout);
             return zout;
           },
-          bp::args("self", "z"))
+          ("self"_a, "z"))
       .def("applyProjectionJacobian", &ConstraintSet::applyProjectionJacobian,
-           bp::args("self", "z", "Jout"), "Apply the projection Jacobian.")
+           ("self"_a, "z", "Jout"), "Apply the projection Jacobian.")
       .def("applyNormalProjectionJacobian",
            &ConstraintSet::applyNormalConeProjectionJacobian,
-           bp::args("self", "z", "Jout"),
+           ("self"_a, "z", "Jout"),
            "Apply the normal cone projection Jacobian.")
       .def("computeActiveSet", &ConstraintSet::computeActiveSet,
-           bp::args("self", "z", "out"))
+           ("self"_a, "z", "out"))
       .def("evaluateMoreauEnvelope", &ConstraintSet::evaluateMoreauEnvelope,
-           bp::args("self", "zin", "zproj"),
+           ("self"_a, "zin", "zproj"),
            "Evaluate the Moreau envelope with parameter :math:`\\mu`.")
       .def("setProxParameter", &ConstraintSet::setProxParameter,
-           bp::args("self", "mu"), "Set proximal parameter.")
+           ("self"_a, "mu"), "Set proximal parameter.")
       .add_property("mu", &ConstraintSet::mu, "Current proximal parameter.")
       .def(bp::self == bp::self);
 
   bp::class_<Constraint>(
       "ConstraintObject", "Packs a constraint set together with a function.",
-      bp::init<shared_ptr<C2Function>, shared_ptr<ConstraintSet>>(
-          bp::args("self", "func", "set")))
+      bp::init<shared_ptr<C2Function>, const polymorphic<ConstraintSet> &>(
+          ("self"_a, "func", "constraint_set")))
       .add_property("nr", &Constraint::nr, "Constraint dimension.")
       .def_readonly("func", &Constraint::func_, "Underlying function.")
       .def_readonly("set", &Constraint::set_, "Constraint set.");
@@ -125,7 +125,7 @@ static void exposeConstraintTypes() {
 
   exposeSpecificConstraintSet<ConstraintSetProduct>(
       "ConstraintSetProduct", "Cartesian product of constraint sets.")
-      .def(bp::init<std::vector<xyz::polymorphic<ConstraintSet>>,
+      .def(bp::init<std::vector<polymorphic<ConstraintSet>>,
                     std::vector<Eigen::Index>>(
           ("self"_a, "components", "blockSizes")))
       .add_property("components",

--- a/bindings/python/expose-constraint.cpp
+++ b/bindings/python/expose-constraint.cpp
@@ -80,7 +80,8 @@ void exposeConstraints() {
   bp::class_<Constraint>(
       "ConstraintObject", "Packs a constraint set together with a function.",
       bp::init<shared_ptr<C2Function>, const polymorphic<ConstraintSet> &>(
-          ("self"_a, "func", "constraint_set")))
+          ("self"_a, "func",
+           "constraint_set"))[bp::with_custodian_and_ward<1, 3>()])
       .add_property("nr", &Constraint::nr, "Constraint dimension.")
       .def_readonly("func", &Constraint::func_, "Underlying function.")
       .def_readonly("set", &Constraint::set_, "Constraint set.");
@@ -126,7 +127,8 @@ static void exposeConstraintTypes() {
       "ConstraintSetProduct", "Cartesian product of constraint sets.")
       .def(bp::init<std::vector<polymorphic<ConstraintSet>>,
                     std::vector<Eigen::Index>>(
-          ("self"_a, "components", "blockSizes")))
+          ("self"_a, "components",
+           "blockSizes"))[bp::with_custodian_and_ward<1, 2>()])
       .add_property("components",
                     bp::make_function(&ConstraintSetProduct::components,
                                       bp::return_internal_reference<>()))

--- a/bindings/python/expose-manifold.cpp
+++ b/bindings/python/expose-manifold.cpp
@@ -144,9 +144,10 @@ void exposeCartesianProduct();
 /// and no-arg default constructor.
 template <typename LieGroup>
 void exposeLieGroup(const char *name, const char *docstring) {
-  bp::class_<PinocchioLieGroup<LieGroup>, bp::bases<Manifold>>(
-      name, docstring, bp::init<>("self"_a))
-      .def(PolymorphicVisitor<PolyManifold>());
+  bp::class_<PinocchioLieGroup<LieGroup>, bp::bases<Manifold>> cl(
+      name, docstring, bp::init<>("self"_a));
+  cl.def(PolymorphicVisitor<PolyManifold>());
+  cl.enable_pickling_(true);
 }
 
 void exposePinocchioSpaces() {

--- a/bindings/python/expose-manifold.cpp
+++ b/bindings/python/expose-manifold.cpp
@@ -91,7 +91,7 @@ void exposeManifoldBase() {
             m.Jdifference(x0, x1, Jout, arg);
             return Jout;
           },
-          ("self"_a, "x", "v", "arg"),
+          ("self"_a, "x0", "x1", "arg"),
           "Compute and return the Jacobian of the log.")
       .def("tangent_space", &Manifold::tangentSpace, bp::args("self"),
            "Returns an object representing the tangent space to this manifold.")

--- a/bindings/python/expose-manifold.cpp
+++ b/bindings/python/expose-manifold.cpp
@@ -10,6 +10,10 @@
 #include "proxsuite-nlp/modelling/spaces/vector-space.hpp"
 #include "proxsuite-nlp/modelling/spaces/tangent-bundle.hpp"
 
+#include <eigenpy/std-vector.hpp>
+
+#include <vector>
+
 namespace proxsuite {
 namespace nlp {
 namespace python {
@@ -105,6 +109,11 @@ void exposeManifoldBase() {
           "__rmul__", +[](const PolyManifold &a, const CartesianProduct &b) {
             return a * b;
           });
+
+  eigenpy::StdVectorPythonVisitor<std::vector<PolyManifold>>::expose(
+      "StdVec_Manifold",
+      eigenpy::details::overload_base_get_item_for_std_vector<
+          std::vector<PolyManifold>>());
 }
 
 /// Expose the tangent bundle of a manifold type @p M.

--- a/bindings/python/expose-manifold.cpp
+++ b/bindings/python/expose-manifold.cpp
@@ -112,13 +112,13 @@ template <typename M>
 bp::class_<TangentBundleTpl<M>, bp::bases<Manifold>>
 exposeTangentBundle(const char *name, const char *docstring) {
   using OutType = TangentBundleTpl<M>;
-  bp::implicitly_convertible<OutType, PolyManifold>();
   return bp::class_<OutType, bp::bases<Manifold>>(
              name, docstring, bp::init<M>(("self"_a, "base")))
       .add_property("base",
                     bp::make_function(&OutType::getBaseSpace,
                                       bp::return_internal_reference<>()),
-                    "Get the base space.");
+                    "Get the base space.")
+      .def(PolymorphicVisitor<PolyManifold>());
 }
 
 /// Expose the tangent bundle with an additional constructor.
@@ -136,8 +136,8 @@ void exposeCartesianProduct();
 template <typename LieGroup>
 void exposeLieGroup(const char *name, const char *docstring) {
   bp::class_<PinocchioLieGroup<LieGroup>, bp::bases<Manifold>>(
-      name, docstring, bp::init<>("self"_a));
-  bp::implicitly_convertible<PinocchioLieGroup<LieGroup>, PolyManifold>();
+      name, docstring, bp::init<>("self"_a))
+      .def(PolymorphicVisitor<PolyManifold>());
 }
 
 void exposePinocchioSpaces() {
@@ -151,9 +151,8 @@ void exposePinocchioSpaces() {
   bp::class_<PinocchioLieGroup<DynSizeEuclideanSpace>, bp::bases<Manifold>>(
       "EuclideanSpace", "Pinocchio's n-dimensional Euclidean vector space.",
       bp::no_init)
-      .def(bp::init<int>(("self"_a, "dim")));
-  bp::implicitly_convertible<PinocchioLieGroup<DynSizeEuclideanSpace>,
-                             PolyManifold>();
+      .def(bp::init<int>(("self"_a, "dim")))
+      .def(PolymorphicVisitor<PolyManifold>());
 
   exposeLieGroup<VectorSpaceOperationTpl<1, Scalar>>(
       "R", "One-dimensional Euclidean space AKA real number line.");
@@ -191,17 +190,16 @@ void exposePinocchioSpaces() {
   /* Groups associated w/ Pinocchio models */
   using Multibody = MultibodyConfiguration<Scalar>;
   using Model = ModelTpl<Scalar>;
-  bp::implicitly_convertible<Multibody, PolyManifold>();
   bp::class_<Multibody, bp::bases<Manifold>>(
       "MultibodyConfiguration", "Configuration group of a multibody",
       bp::init<const Model &>(bp::args("self", "model")))
       .add_property("model",
                     bp::make_function(&Multibody::getModel,
                                       bp::return_internal_reference<>()),
-                    "Return the Pinocchio model instance.");
+                    "Return the Pinocchio model instance.")
+      .def(PolymorphicVisitor<PolyManifold>());
 
   using MultiPhase = MultibodyPhaseSpace<Scalar>;
-  bp::implicitly_convertible<MultiPhase, PolyManifold>();
   bp::class_<MultiPhase, bp::bases<Manifold>>(
       "MultibodyPhaseSpace",
       "Tangent space of the multibody configuration group.",
@@ -214,7 +212,8 @@ void exposePinocchioSpaces() {
                                 +[](const MultiPhase &m) -> const Multibody & {
                                   return m.getBaseSpace();
                                 },
-                                bp::return_internal_reference<>()));
+                                bp::return_internal_reference<>()))
+      .def(PolymorphicVisitor<PolyManifold>());
 }
 #endif
 
@@ -225,8 +224,8 @@ void exposeManifolds() {
   /* Basic vector space */
   bp::class_<VectorSpaceTpl<Scalar>, bp::bases<Manifold>>(
       "VectorSpace", "Basic Euclidean vector space.", bp::no_init)
-      .def(bp::init<const int>(("self"_a, "dim")));
-  bp::implicitly_convertible<VectorSpaceTpl<Scalar>, PolyManifold>();
+      .def(bp::init<const int>(("self"_a, "dim")))
+      .def(PolymorphicVisitor<PolyManifold>());
 
   exposeCartesianProduct();
 #ifdef PROXSUITE_NLP_WITH_PINOCCHIO

--- a/bindings/python/expose-problem.cpp
+++ b/bindings/python/expose-problem.cpp
@@ -1,6 +1,6 @@
 #include "proxsuite-nlp/python/fwd.hpp"
 #include "proxsuite-nlp/problem-base.hpp"
-#include "proxsuite-nlp/modelling/constraints.hpp"
+#include "proxsuite-nlp/constraint-base.hpp"
 
 namespace proxsuite {
 namespace nlp {

--- a/bindings/python/expose-problem.cpp
+++ b/bindings/python/expose-problem.cpp
@@ -14,8 +14,7 @@ void exposeProblem() {
   bp::class_<Problem>("Problem", "Problem definition class.", bp::no_init)
       .def(bp::init<const polymorphic<Manifold> &, shared_ptr<context::Cost>,
                     const std::vector<Constraint> &>(
-          ("self"_a, "space", "cost",
-           "constraints"_a = bp::list()))[bp::with_custodian_and_ward<1, 2>()])
+          ("self"_a, "space", "cost", "constraints"_a = bp::list())))
       .def_readwrite("cost", &Problem::cost_, "The cost function instance.")
       .def_readwrite("manifold", &Problem::manifold_, "Problem manifold.")
       .add_property("num_constraint_blocks", &Problem::getNumConstraints,

--- a/bindings/python/expose-problem.cpp
+++ b/bindings/python/expose-problem.cpp
@@ -12,10 +12,9 @@ void exposeProblem() {
   using context::Problem;
 
   bp::class_<Problem>("Problem", "Problem definition class.", bp::no_init)
-      .def(bp::init<shared_ptr<Manifold>, shared_ptr<context::Cost>,
+      .def(bp::init<const polymorphic<Manifold> &, shared_ptr<context::Cost>,
                     const std::vector<Constraint> &>(
-          (bp::arg("self"), bp::arg("space"), bp::arg("cost"),
-           bp::arg("constraints") = bp::list())))
+          ("self"_a, "space", "cost", "constraints"_a = bp::list())))
       .def_readwrite("cost", &Problem::cost_, "The cost function instance.")
       .def_readwrite("manifold", &Problem::manifold_, "Problem manifold.")
       .add_property("num_constraint_blocks", &Problem::getNumConstraints,
@@ -25,7 +24,7 @@ void exposeProblem() {
       .add_property("nx", &Problem::nx, "Get the problem tangent space dim.")
       .add_property("ndx", &Problem::ndx, "Get the problem tangent space dim.")
       .def("add_constraint", &Problem::addConstraint<const Constraint &>,
-           bp::args("self", "cstr"), "Add a constraint to the problem.");
+           ("self"_a, "cstr"), "Add a constraint to the problem.");
 }
 
 } // namespace python

--- a/bindings/python/expose-problem.cpp
+++ b/bindings/python/expose-problem.cpp
@@ -14,7 +14,8 @@ void exposeProblem() {
   bp::class_<Problem>("Problem", "Problem definition class.", bp::no_init)
       .def(bp::init<const polymorphic<Manifold> &, shared_ptr<context::Cost>,
                     const std::vector<Constraint> &>(
-          ("self"_a, "space", "cost", "constraints"_a = bp::list())))
+          ("self"_a, "space", "cost",
+           "constraints"_a = bp::list()))[bp::with_custodian_and_ward<1, 2>()])
       .def_readwrite("cost", &Problem::cost_, "The cost function instance.")
       .def_readwrite("manifold", &Problem::manifold_, "Problem manifold.")
       .add_property("num_constraint_blocks", &Problem::getNumConstraints,

--- a/bindings/python/expose-quadratic-costs.cpp
+++ b/bindings/python/expose-quadratic-costs.cpp
@@ -44,12 +44,13 @@ void exposeQuadraticCosts() {
       "Quadratic distance cost `(1/2)r.T * Q * r + b.T * r + c` on the "
       "manifold.",
       bp::init<PolyManifold, const VectorXs &, const MatrixXs &>(
-          bp::args("self", "space", "target", "weights")))
-      .def(bp::init<PolyManifold, const VectorXs &>(
-          bp::args("self", "space", "target")))
+          bp::args("self", "space", "target",
+                   "weights"))[bp::with_custodian_and_ward<1, 2>()])
+      .def(bp::init<PolyManifold, const VectorXs &>(bp::args(
+          "self", "space", "target"))[bp::with_custodian_and_ward<1, 2>()])
       .def(bp::init<PolyManifold>(
           "Constructor which uses the neutral element of the space.",
-          bp::args("self", "space")))
+          bp::args("self", "space"))[bp::with_custodian_and_ward<1, 2>()])
       .add_property("target", &QuadraticDistanceCost::getTarget,
                     &QuadraticDistanceCost::updateTarget);
 }

--- a/bindings/python/expose-quadratic-costs.cpp
+++ b/bindings/python/expose-quadratic-costs.cpp
@@ -44,13 +44,12 @@ void exposeQuadraticCosts() {
       "Quadratic distance cost `(1/2)r.T * Q * r + b.T * r + c` on the "
       "manifold.",
       bp::init<PolyManifold, const VectorXs &, const MatrixXs &>(
-          bp::args("self", "space", "target",
-                   "weights"))[bp::with_custodian_and_ward<1, 2>()])
-      .def(bp::init<PolyManifold, const VectorXs &>(bp::args(
-          "self", "space", "target"))[bp::with_custodian_and_ward<1, 2>()])
+          bp::args("self", "space", "target", "weights")))
+      .def(bp::init<PolyManifold, const VectorXs &>(
+          bp::args("self", "space", "target")))
       .def(bp::init<PolyManifold>(
           "Constructor which uses the neutral element of the space.",
-          bp::args("self", "space"))[bp::with_custodian_and_ward<1, 2>()])
+          bp::args("self", "space")))
       .add_property("target", &QuadraticDistanceCost::getTarget,
                     &QuadraticDistanceCost::updateTarget);
 }

--- a/bindings/python/expose-quadratic-costs.cpp
+++ b/bindings/python/expose-quadratic-costs.cpp
@@ -16,7 +16,7 @@ using context::VectorXs;
 
 void exposeQuadraticCosts() {
   using FunctionPtr = shared_ptr<context::C2Function>;
-  using ManifoldPtr = shared_ptr<context::Manifold>;
+  using PolyManifold = polymorphic<context::Manifold>;
 
   using QuadraticResidualCost = QuadraticResidualCostTpl<Scalar>;
   bp::class_<QuadraticResidualCost, bp::bases<Cost>>(
@@ -43,11 +43,11 @@ void exposeQuadraticCosts() {
       "QuadraticDistanceCost",
       "Quadratic distance cost `(1/2)r.T * Q * r + b.T * r + c` on the "
       "manifold.",
-      bp::init<ManifoldPtr, const VectorXs &, const MatrixXs &>(
+      bp::init<PolyManifold, const VectorXs &, const MatrixXs &>(
           bp::args("self", "space", "target", "weights")))
-      .def(bp::init<ManifoldPtr, const VectorXs &>(
+      .def(bp::init<PolyManifold, const VectorXs &>(
           bp::args("self", "space", "target")))
-      .def(bp::init<ManifoldPtr>(
+      .def(bp::init<PolyManifold>(
           "Constructor which uses the neutral element of the space.",
           bp::args("self", "space")))
       .add_property("target", &QuadraticDistanceCost::getTarget,

--- a/bindings/python/expose-residual.cpp
+++ b/bindings/python/expose-residual.cpp
@@ -30,14 +30,14 @@ void exposeResiduals() {
   expose_function<ManifoldDifferenceToPoint<Scalar>>(
       "ManifoldDifferenceToPoint", "Difference vector x (-) x0.",
       bp::init<const polymorphic<Manifold> &, const ConstVectorRef &>(
-          bp::args("self", "space", "target")))
+          ("self"_a, "space", "target")))
       .add_property("target", &ManifoldDifferenceToPoint<Scalar>::target_);
 
   expose_function<LinearFunctionDifferenceToPoint<Scalar>>(
       "LinearFunctionDifferenceToPoint",
       "Linear function of the vector difference to a reference point.",
       bp::init<const polymorphic<Manifold> &, VectorXs, MatrixXs, VectorXs>(
-          bp::args("self", "space", "target", "A", "b")));
+          ("self"_a, "space", "target", "A", "b")));
 }
 
 } // namespace python

--- a/bindings/python/expose-residual.cpp
+++ b/bindings/python/expose-residual.cpp
@@ -30,15 +30,14 @@ void exposeResiduals() {
   expose_function<ManifoldDifferenceToPoint<Scalar>>(
       "ManifoldDifferenceToPoint", "Difference vector x (-) x0.",
       bp::init<const polymorphic<Manifold> &, const ConstVectorRef &>(
-          ("self"_a, "space", "target"))[bp::with_custodian_and_ward<1, 2>()])
+          ("self"_a, "space", "target")))
       .add_property("target", &ManifoldDifferenceToPoint<Scalar>::target_);
 
   expose_function<LinearFunctionDifferenceToPoint<Scalar>>(
       "LinearFunctionDifferenceToPoint",
       "Linear function of the vector difference to a reference point.",
       bp::init<const polymorphic<Manifold> &, VectorXs, MatrixXs, VectorXs>(
-          ("self"_a, "space", "target", "A",
-           "b"))[bp::with_custodian_and_ward<1, 2>()]);
+          ("self"_a, "space", "target", "A", "b")));
 }
 
 } // namespace python

--- a/bindings/python/expose-residual.cpp
+++ b/bindings/python/expose-residual.cpp
@@ -30,14 +30,15 @@ void exposeResiduals() {
   expose_function<ManifoldDifferenceToPoint<Scalar>>(
       "ManifoldDifferenceToPoint", "Difference vector x (-) x0.",
       bp::init<const polymorphic<Manifold> &, const ConstVectorRef &>(
-          ("self"_a, "space", "target")))
+          ("self"_a, "space", "target"))[bp::with_custodian_and_ward<1, 2>()])
       .add_property("target", &ManifoldDifferenceToPoint<Scalar>::target_);
 
   expose_function<LinearFunctionDifferenceToPoint<Scalar>>(
       "LinearFunctionDifferenceToPoint",
       "Linear function of the vector difference to a reference point.",
       bp::init<const polymorphic<Manifold> &, VectorXs, MatrixXs, VectorXs>(
-          ("self"_a, "space", "target", "A", "b")));
+          ("self"_a, "space", "target", "A",
+           "b"))[bp::with_custodian_and_ward<1, 2>()]);
 }
 
 } // namespace python

--- a/bindings/python/expose-residual.cpp
+++ b/bindings/python/expose-residual.cpp
@@ -29,14 +29,14 @@ void exposeResiduals() {
 
   expose_function<ManifoldDifferenceToPoint<Scalar>>(
       "ManifoldDifferenceToPoint", "Difference vector x (-) x0.",
-      bp::init<const shared_ptr<Manifold> &, const ConstVectorRef &>(
+      bp::init<const polymorphic<Manifold> &, const ConstVectorRef &>(
           bp::args("self", "space", "target")))
       .add_property("target", &ManifoldDifferenceToPoint<Scalar>::target_);
 
   expose_function<LinearFunctionDifferenceToPoint<Scalar>>(
       "LinearFunctionDifferenceToPoint",
       "Linear function of the vector difference to a reference point.",
-      bp::init<const shared_ptr<Manifold> &, VectorXs, MatrixXs, VectorXs>(
+      bp::init<const polymorphic<Manifold> &, VectorXs, MatrixXs, VectorXs>(
           bp::args("self", "space", "target", "A", "b")));
 }
 

--- a/bindings/python/include/proxsuite-nlp/python/fwd.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/fwd.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <eigenpy/eigenpy.hpp>
-
 #include "proxsuite-nlp/context.hpp"
+#include <eigenpy/eigenpy.hpp>
 
 namespace proxsuite {
 namespace nlp {

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -2,7 +2,10 @@
 #include "proxsuite-nlp/python/fwd.hpp"
 #include "proxsuite-nlp/third-party/polymorphic_cxx14.hpp"
 #include "proxsuite-nlp/macros.hpp"
+
 #include <eigenpy/utils/traits.hpp>
+
+#include <variant>
 
 // Required class template specialization for
 // boost::python::register_ptr_to_python<> to work.
@@ -36,7 +39,7 @@ struct PolymorphicVisitor<xyz::polymorphic<Base, A>>
   using Poly = xyz::polymorphic<Base, A>;
   static_assert(std::is_polymorphic_v<Base>, "Type should be polymorphic!");
 
-  template <class PyClass> void visit(PyClass &) const {
+  template <class PyClass> void visit(PyClass &cl) const {
     using T = typename PyClass::wrapped_type;
     using meta = typename PyClass::metadata;
     using held = typename meta::held_type;
@@ -48,138 +51,196 @@ struct PolymorphicVisitor<xyz::polymorphic<Base, A>>
         &functions::convertible, &functions::construct, bp::type_id<Poly>(),
         &bp::converter::expected_from_python_type_direct<T>::get_pytype);
     PROXSUITE_NLP_COMPILER_DIAGNOSTIC_POP
+
+    // Enable pickling of the Derived Python class.
+    // If a Python class inherit from cl, this call will allow pickle to
+    // serialize/unserialize all the Python class content.
+    // The C++ part will not be serialized but it's managed differently
+    // by PolymorphicWrapper.
+    if constexpr (std::is_base_of_v<boost::python::wrapper<Base>,
+                                    typename PyClass::wrapped_type>) {
+      cl.enable_pickling_(true);
+    }
   }
 };
 
-/// Like boost::python::with_custodian_and_ward but the ward must be a list
-/// and with_custodian_and_ward memory management will be applied on each
-/// element of contained in the ward.
-template <std::size_t custodian, std::size_t ward,
-          class BasePolicy_ = bp::default_call_policies>
-struct with_custodian_and_ward_list_content : BasePolicy_ {
-  BOOST_STATIC_ASSERT(custodian != ward);
-  BOOST_STATIC_ASSERT(custodian > 0);
-  BOOST_STATIC_ASSERT(ward > 0);
+// Specialize value_holder to allow switching to a non owning holder.
+// This code is similar to boost::python::value_holder code but allow to switch
+// between value or ptr at runtime.
+template <typename Value>
+struct OwningNonOwningHolder : boost::python::instance_holder {
+  typedef Value held_type;
+  typedef Value value_type;
 
-  template <class ArgumentPackage>
-  static bool precall(ArgumentPackage const &args_) {
-    unsigned arity_ = bp::detail::arity(args_);
-    if (custodian > arity_ || ward > arity_) {
-      PyErr_SetString(
-          PyExc_IndexError,
-          "with_custodian_and_ward_list_content: argument index out of range");
-      return false;
-    }
+private:
+  struct PtrGetter {
+    Value *operator()(Value &v) { return &v; };
+    Value *operator()(Value *v) { return v; };
+  };
 
-    PyObject *patient = bp::detail::get_prev<ward>::execute(args_);
-    PyObject *nurse = bp::detail::get_prev<custodian>::execute(args_);
+  Value *get_ptr() { return std::visit(PtrGetter(), m_held); }
 
-    // Check if patient is a list
-    if (!PyList_Check(patient)) {
-      PyErr_SetString(
-          PyExc_TypeError,
-          "with_custodian_and_ward_list_content: ward must be a list");
-      return false;
-    }
-
-    // Retrieve the underlying list.
-    // TODO I'm not sure the bp::handle is mandatory here.
-    // I don't think we will call Python interpreter some how and
-    // delete the patient reference (See
-    // https://docs.python.org/3/extending/extending.html#thin-ice).
-    bp::object patient_obj(bp::handle<>(bp::borrowed(patient)));
-    bp::list patient_list(patient_obj);
-
-    // Add life_support for each element of the patient_list
-    bp::ssize_t list_size = bp::len(patient_list);
-    std::vector<PyObject *> life_support_list;
-    life_support_list.reserve(list_size);
-    for (bp::ssize_t k = 0; k < list_size; ++k) {
-      auto l = patient_list[k];
-      PyObject *life_support = bp::objects::make_nurse_and_patient(
-          nurse, bp::object(patient_list[k]).ptr());
-      if (life_support == 0) {
-        for (PyObject *ls : life_support_list) {
-          Py_DECREF(ls);
-        }
-        return false;
-      }
-      life_support_list.push_back(life_support);
-    }
-
-    bool result = BasePolicy_::precall(args_);
-
-    if (!result) {
-      for (PyObject *ls : life_support_list) {
-        Py_DECREF(ls);
-      }
-    }
-
-    return result;
+public:
+  template <typename... Args>
+  OwningNonOwningHolder(PyObject *self, Args... args)
+      : m_held(std::forward<Args>(args)...) {
+    boost::python::detail::initialize_wrapper(self, get_ptr());
   }
+
+private: // required holder implementation
+  void *holds(boost::python::type_info dst_t, bool) {
+    if (void *wrapped = holds_wrapped(dst_t, get_ptr(), get_ptr()))
+      return wrapped;
+
+    boost::python::type_info src_t = boost::python::type_id<Value>();
+    return src_t == dst_t ? get_ptr()
+                          : boost::python::objects::find_static_type(
+                                get_ptr(), src_t, dst_t);
+  }
+
+  template <class T>
+  inline void *holds_wrapped(boost::python::type_info dst_t,
+                             boost::python::wrapper<T> *, T *p) {
+    return boost::python::type_id<T>() == dst_t ? p : 0;
+  }
+
+  inline void *holds_wrapped(boost::python::type_info, ...) { return 0; }
+
+public: // data members
+  std::variant<Value, Value *> m_held;
 };
 
-} // namespace python
-} // namespace proxsuite::nlp
+// This class replace boost::python::wrapper when we want to use
+// xyz::polymorphic to hold polymorphic class.
+//
+// The following class diagram describe how boost::python::wrapper work:
+//
+// PyDerived -----------|
+//    ^      1  m_self  |
+//    |                 |
+//  PyBase <--- wrapper--
+//    ^
+//    |
+//   Base
+//
+// PyDerived is a Python class that inherit from PyBase.
+// Wrapper will hold a non owning ptr to PyDerived.
+// This can lead to ownership issue when PyBase is stored in C++ object.
+//
+// To avoid this issue, at each PolymorphicWrapper copy, we will deep copy and
+// own m_self in copied_owner.
+// When copied, m self will default construct a new PyBase instance.
+// To avoid having two PyBase instance (the one copied in C++ and the other one
+// default constructed by Boost.Python) we store PyBase in a custom holder
+// (OwningNonOwningHolder) and we reset this holder to hold a ptr to the new C++
+// instance.
+template <typename _PyBase, typename _Base>
+struct PolymorphicWrapper : boost::python::wrapper<_Base> {
+  using PyBase = _PyBase;
+  using Base = _Base;
 
-namespace boost {
-namespace python {
+  PolymorphicWrapper() = default;
+  PolymorphicWrapper(const PolymorphicWrapper &o) : bp::wrapper<Base>(o) {
+    deepcopy_owner();
+  }
+  PolymorphicWrapper(PolymorphicWrapper &&o) = default;
+
+  PolymorphicWrapper &operator=(const PolymorphicWrapper &o) {
+    if (this == &o) {
+      return *this;
+    }
+    bp::wrapper<Base>::operator=(o);
+    deepcopy_owner();
+    return *this;
+  }
+  PolymorphicWrapper &operator=(PolymorphicWrapper &&o) = default;
+
+private:
+  void deepcopy_owner() {
+    namespace bp = boost::python;
+    if (PyObject *owner_ptr = bp::detail::wrapper_base_::get_owner(*this)) {
+      bp::object copy = bp::import("copy");
+      bp::object deepcopy = copy.attr("deepcopy");
+
+      // bp::object decrements the refcount at destruction
+      // so by calling it with borrowed we incref owner_ptr to avoid destroying
+      // it.
+      bp::object owner{bp::handle<>(boost::python::borrowed(owner_ptr))};
+
+      // Deepcopy is safer to copy derived class values but don't copy C++ class
+      // content.
+      // We store the copied owner into a member variable to take the
+      // ownership.
+      copied_owner = deepcopy(owner);
+      PyObject *copied_owner_ptr = copied_owner.ptr();
+
+      // copied_owner contains a OwningNonOwningHolder<PyBase> that contains a
+      // PyBase (different from this).
+      // We modify this value_holder specialization to store this ptr (non
+      // owning) instead. This will avoid that Python and C++ work with
+      // different object. Since copied_owner is owned by this, there is no
+      // memory leak.
+      // TODO check value holder type
+      bp::objects::instance<> *inst =
+          ((bp::objects::instance<> *)copied_owner_ptr);
+      OwningNonOwningHolder<PyBase> *value_holder =
+          (OwningNonOwningHolder<PyBase> *)inst->objects;
+      value_holder->m_held = static_cast<PyBase *>(this);
+
+      bp::detail::initialize_wrapper(copied_owner_ptr, this);
+    }
+  }
+
+private:
+  bp::object copied_owner;
+};
+
+namespace internal {
 
 /// Use the same trick from <eigenpy/eigen-to-python.hpp> to specialize the
 /// template for both const and non-const.
 /// This specialization do the same thing than to_python_indirect with the
 /// following differences:
 /// - Return the content of the xyz::polymorphic
-/// - Don't incref owner Python object if the xyz::polymorphic content inherit
-///   of bp::wrapper to avoid memory leak
-/// \warning This converter should only be called by
-/// bp::return_internal_reference, because return_internal_reference will link
-/// returned object lifetime to the owner object lifetime.
-template <class poly_ref, class MakeHolder> struct to_python_indirect_poly {
-  using poly_type = remove_cv_ref_t<poly_ref>;
-  template <class U> PyObject *operator()(U const &ref) const {
-    return this->execute(const_cast<U &>(ref), detail::is_pointer<U>());
+template <class poly_ref, class MakeHolder> struct ToPythonIndirectPoly {
+  using poly_type = boost::remove_cv_ref_t<poly_ref>;
+
+  template <class U> PyObject *operator()(U const &x) const {
+    return execute(const_cast<U &>(x));
   }
 #ifndef BOOST_PYTHON_NO_PY_SIGNATURES
   PyTypeObject const *get_pytype() {
-    return converter::registered_pytype<poly_type>::get_pytype();
+    return boost::python::converter::registered_pytype<poly_type>::get_pytype();
   }
 #endif
 
 private:
   template <class T, class A>
-  inline PyObject *execute(xyz::polymorphic<T, A> *ptr, detail::true_) const {
-    // No special NULL treatment for references
-    if (ptr == 0)
-      return detail::none();
-    else
-      return this->execute(*ptr, detail::false_());
-  }
-
-  template <class T, class A>
-  inline PyObject *execute(xyz::polymorphic<T, A> const &x,
-                           detail::false_) const {
-    if (x.valueless_after_move())
-      return detail::none();
-    T *const p = const_cast<T *>(boost::get_pointer(x));
-    if (PyObject *o = detail::wrapper_base_::owner(p)) {
-      // to_python_indirect call incref on o, but this create a memory leak
-      // when used with bp::return_internal_reference.
-      // TODO Without incref, if we call multiple time return_internal_reference
-      // on the same member, this create an undefined behavior
-      return incref(o);
-    }
-    return MakeHolder::execute(p);
+  static PyObject *execute(const xyz::polymorphic<T, A> &p) {
+    if (p.valueless_after_move())
+      return bp::detail::none();
+    T *q = const_cast<T *>(boost::get_pointer(p));
+    assert(q);
+    return bp::to_python_indirect<const T &, MakeHolder>{}(q);
   }
 };
 
+} // namespace internal
+} // namespace python
+} // namespace proxsuite::nlp
+
+namespace boost {
+namespace python {
+
 template <class T, class A, class MakeHolder>
 struct to_python_indirect<xyz::polymorphic<T, A> &, MakeHolder>
-    : to_python_indirect_poly<xyz::polymorphic<T, A> &, MakeHolder> {};
+    : proxsuite::nlp::python::internal::ToPythonIndirectPoly<
+          xyz::polymorphic<T, A> &, MakeHolder> {};
 
 template <class T, class A, class MakeHolder>
 struct to_python_indirect<const xyz::polymorphic<T, A> &, MakeHolder>
-    : to_python_indirect_poly<const xyz::polymorphic<T, A> &, MakeHolder> {};
+    : proxsuite::nlp::python::internal::ToPythonIndirectPoly<
+          const xyz::polymorphic<T, A> &, MakeHolder> {};
 
 } // namespace python
 } // namespace boost

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -3,37 +3,17 @@
 #include "proxsuite-nlp/third-party/polymorphic_cxx14.hpp"
 #include <eigenpy/utils/traits.hpp>
 
+// Required class template specialization for
+// boost::python::register_ptr_to_python<> to work.
+namespace boost::python {
+template <class T, class A> struct pointee<xyz::polymorphic<T, A>> {
+  typedef T type;
+};
+} // namespace boost::python
+
 namespace proxsuite::nlp {
 namespace python {
 namespace detail {
-template <class held_type> struct PolymorphicHolder;
-
-/// @brief Owning holder for the xyz::polymorphic<T, A> polymorphic value type.
-template <class _T, class _A>
-struct PolymorphicHolder<polymorphic<_T, _A>> : bp::instance_holder {
-  static_assert(std::is_polymorphic_v<_T>, "Held type should be polymorphic.");
-  using polymorphic_t = polymorphic<_T, _A>;
-  using value_type = _T;
-  using allocator_type = _A;
-
-  template <typename U> PolymorphicHolder(U &&u) : m_p(std::forward<U>(u)) {}
-
-private:
-  void *holds(bp::type_info dst_t, bool /*null_ptr_only*/) override {
-    if (dst_t == bp::type_id<polymorphic_t>()) {
-      // return pointer to the held data
-      return &this->m_p;
-    }
-    value_type *p = boost::get_pointer(m_p);
-    if (dst_t == bp::type_id<value_type>())
-      return p;
-
-    bp::type_info src_t = bp::type_id<value_type>();
-    return src_t == dst_t ? p : bp::objects::find_dynamic_type(p, src_t, dst_t);
-  }
-
-  polymorphic_t m_p;
-};
 
 struct make_polymorphic_reference_holder {
   template <class T, class A>

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -5,6 +5,8 @@
 
 #include <eigenpy/utils/traits.hpp>
 
+#include <boost/core/demangle.hpp>
+
 #include <variant>
 
 // Required class template specialization for
@@ -220,7 +222,14 @@ private:
       bp::objects::instance<> *inst =
           ((bp::objects::instance<> *)copied_owner_ptr);
       OwningNonOwningHolder<PyBase> *value_holder =
-          (OwningNonOwningHolder<PyBase> *)inst->objects;
+          dynamic_cast<OwningNonOwningHolder<PyBase> *>(inst->objects);
+      if (!value_holder) {
+        std::ostringstream error_msg;
+        error_msg << "OwningNonOwningHolder should be setup for "
+                  << boost::core::demangle(typeid(PyBase).name()) << " type"
+                  << std::endl;
+        throw std::logic_error(error_msg.str());
+      }
       value_holder->m_held = static_cast<PyBase *>(this);
 
       bp::detail::initialize_wrapper(copied_owner_ptr, this);

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -88,8 +88,8 @@ namespace python {
 
 /// Use the same trick from <eigenpy/eigen-to-python.hpp> to specialize the
 /// template for both const and non-const
-template <class X, class MakeHolder> struct to_python_indirect_poly {
-  using poly_type = boost::remove_cv_ref_t<X>;
+template <class poly_ref, class MakeHolder> struct to_python_indirect_poly {
+  using poly_type = boost::remove_cv_ref_t<poly_ref>;
   template <class U> PyObject *operator()(U const &x) const {
     return ::proxsuite::nlp::python::detail::make_polymorphic_reference_holder::
         execute(const_cast<U &>(x));

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -75,9 +75,10 @@ template <class Poly> void register_polymorphic_to_python() {
 namespace boost {
 namespace python {
 
-template <class T, class A, class MakeHolder>
-struct to_python_indirect<xyz::polymorphic<T, A> &, MakeHolder> {
-  using poly_type = xyz::polymorphic<T, A>;
+/// Use the same trick from <eigenpy/eigen-to-python.hpp> to specialize the
+/// template for both const and non-const
+template <class X, class MakeHolder> struct to_python_indirect_poly {
+  using poly_type = typename eigenpy::details::remove_cvref<X>::type;
   template <class U> PyObject *operator()(U const &x) const {
     if (x.valueless_after_move()) {
       return detail::none();
@@ -91,6 +92,14 @@ struct to_python_indirect<xyz::polymorphic<T, A> &, MakeHolder> {
   }
 #endif
 };
+
+template <class T, class A, class MakeHolder>
+struct to_python_indirect<xyz::polymorphic<T, A> &, MakeHolder>
+    : to_python_indirect_poly<xyz::polymorphic<T, A> &, MakeHolder> {};
+
+template <class T, class A, class MakeHolder>
+struct to_python_indirect<const xyz::polymorphic<T, A> &, MakeHolder>
+    : to_python_indirect_poly<const xyz::polymorphic<T, A> &, MakeHolder> {};
 
 } // namespace python
 } // namespace boost

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -1,14 +1,6 @@
 #pragma once
-#include "proxsuite-nlp/third-party/polymorphic_cxx14.hpp"
-
-namespace boost {
-template <typename T> T *get_pointer(xyz::polymorphic<T> const &p) {
-  const T &r = *p;
-  return const_cast<T *>(&r);
-}
-} // namespace boost
-
 #include "proxsuite-nlp/python/fwd.hpp"
+#include "proxsuite-nlp/third-party/polymorphic_cxx14.hpp"
 #include <eigenpy/utils/traits.hpp>
 
 namespace proxsuite::nlp {
@@ -37,7 +29,7 @@ private:
       // return pointer to the held data
       return &this->m_p;
     }
-    value_type *p = &(*this->m_p);
+    value_type *p = boost::get_pointer(m_p);
     if (dst_t == bp::type_id<value_type>())
       return p;
 
@@ -78,7 +70,7 @@ namespace python {
 /// Use the same trick from <eigenpy/eigen-to-python.hpp> to specialize the
 /// template for both const and non-const
 template <class X, class MakeHolder> struct to_python_indirect_poly {
-  using poly_type = typename eigenpy::details::remove_cvref<X>::type;
+  using poly_type = boost::remove_cv_ref_t<X>;
   template <class U> PyObject *operator()(U const &x) const {
     if (x.valueless_after_move()) {
       return detail::none();

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -118,7 +118,8 @@ private:
 public:
   template <typename... Args>
   OwningNonOwningHolder(PyObject *self, Args... args)
-      : m_held(std::forward<Args>(args)...) {
+      : m_held(Value(boost::python::objects::do_unforward(
+            std::forward<Args>(args), 0)...)) {
     boost::python::detail::initialize_wrapper(self, get_ptr());
   }
 

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "proxsuite-nlp/python/fwd.hpp"
 #include "proxsuite-nlp/third-party/polymorphic_cxx14.hpp"
+#include "proxsuite-nlp/macros.hpp"
 #include <eigenpy/utils/traits.hpp>
 
 // Required class template specialization for
@@ -41,12 +42,12 @@ struct PolymorphicVisitor<xyz::polymorphic<Base, A>>
     using held = typename meta::held_type;
     typedef bp::converter::implicit<held, Poly> functions;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdelete-non-abstract-non-virtual-dtor"
+    PROXSUITE_NLP_COMPILER_DIAGNOSTIC_PUSH
+    PROXSUITE_NLP_COMPILER_DIAGNOSTIC_IGNORED_DELETE_NON_ABSTRACT_NON_VIRTUAL_DTOR
     bp::converter::registry::insert(
         &functions::convertible, &functions::construct, bp::type_id<Poly>(),
         &bp::converter::expected_from_python_type_direct<T>::get_pytype);
-#pragma GCC diagnostic pop
+    PROXSUITE_NLP_COMPILER_DIAGNOSTIC_POP
   }
 };
 

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -16,10 +16,7 @@ struct PolymorphicHolder<polymorphic<_T, _A>> : bp::instance_holder {
   using value_type = _T;
   using allocator_type = _A;
 
-  PolymorphicHolder(polymorphic_t obj) : m_p(std::move(obj)) {}
-
-  template <typename U>
-  PolymorphicHolder(PyObject *, U u) : m_p(std::move(u)) {}
+  template <typename U> PolymorphicHolder(U &&u) : m_p(std::forward<U>(u)) {}
 
 private:
   void *holds(bp::type_info dst_t, bool /*null_ptr_only*/) override {

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -53,12 +53,17 @@ template <class Poly> inline void register_polymorphic_to_python() {
                 X, bp::objects::pointer_holder<Poly, X>>>();
 }
 
+template <class Poly> struct PolymorphicVisitor;
+
 /// Does the same thing as boost::python::implicitly_convertible<>(),
 /// except the conversion is placed at the top of the conversion chain.
 /// This ensures that Boost.Python attempts to convert to Poly BEFORE
 /// any parent class!
-template <class Poly>
-struct PolymorphicVisitor : bp::def_visitor<PolymorphicVisitor<Poly>> {
+template <class Base, class A>
+struct PolymorphicVisitor<xyz::polymorphic<Base, A>>
+    : bp::def_visitor<PolymorphicVisitor<xyz::polymorphic<Base, A>>> {
+  using Poly = xyz::polymorphic<Base, A>;
+  static_assert(std::is_polymorphic_v<Base>, "Type should be polymorphic!");
 
   template <class PyClass> void visit(PyClass &) const {
     using T = typename PyClass::wrapped_type;

--- a/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/polymorphic.hpp
@@ -165,7 +165,9 @@ private:
     if (PyObject *o = detail::wrapper_base_::owner(p)) {
       // to_python_indirect call incref on o, but this create a memory leak
       // when used with bp::return_internal_reference.
-      return o;
+      // TODO Without incref, if we call multiple time return_internal_reference
+      // on the same member, this create an undefined behavior
+      return incref(o);
     }
     return MakeHolder::execute(p);
   }

--- a/examples/circle.cpp
+++ b/examples/circle.cpp
@@ -18,8 +18,7 @@ using Problem = ProblemTpl<double>;
 
 int main() {
   constexpr int dim = 2;
-  auto space_ = std::make_shared<Manifold>(dim);
-  const Manifold &space = *space_;
+  Manifold space{dim};
   const int nx = space.nx();
   Manifold::PointType p0(nx); // target
   p0 << -.4, .7;
@@ -46,14 +45,14 @@ int main() {
   weights.setIdentity();
 
   auto cost_fun =
-      std::make_shared<QuadraticDistanceCostTpl<double>>(space_, p0, weights);
+      std::make_shared<QuadraticDistanceCostTpl<double>>(space, p0, weights);
   const auto &cf = *cost_fun;
   fmt::print("cost: {}\n", cf.call(p1));
   fmt::print("grad: {}\n", cf.computeGradient(p1));
   fmt::print("hess: {}\n", cf.computeHessian(p1));
 
   using DistResType = ManifoldDifferenceToPoint<double>;
-  auto resptr = std::make_shared<DistResType>(space_, space.neutral());
+  auto resptr = std::make_shared<DistResType>(space, space.neutral());
   const auto &residual = *resptr;
   fmt::print("residual val @ p0: {}\n", residual(p0).transpose());
   fmt::print("residual val @ p1: {}\n", residual(p1).transpose());
@@ -70,11 +69,11 @@ int main() {
   auto residualCirclePtr = std::make_shared<QuadraticResidualCostTpl<double>>(
       resptr, w2, -radius_sq);
 
-  using Ineq_t = NegativeOrthantTpl<double>;
-  using CstrType = Problem::ConstraintObject;
-  CstrType cstr1(residualCirclePtr, std::make_shared<Ineq_t>());
+  using Inequality = NegativeOrthantTpl<double>;
+  using CstrType = ConstraintObjectTpl<double>;
+  CstrType cstr1(residualCirclePtr, Inequality{});
   std::vector<CstrType> cstrs{cstr1};
-  Problem prob(space_, cost_fun, cstrs);
+  Problem prob(space, cost_fun, cstrs);
 
   /// Test out merit functions
 

--- a/examples/equality-qp.cpp
+++ b/examples/equality-qp.cpp
@@ -29,8 +29,7 @@ using SolverType = ProxNLPSolverTpl<double>;
 
 template <int N, int M = 1> int submain() {
   using Manifold = VectorSpaceTpl<double>;
-  auto space_ = std::make_shared<Manifold>(N);
-  const Manifold &space = *space_;
+  Manifold space{N};
   typename Manifold::PointType p1 = space.rand();
 
   Eigen::MatrixXd Qroot(N, N + 1);
@@ -48,14 +47,14 @@ template <int N, int M = 1> int submain() {
   auto res1 = std::make_shared<LinearFunctionTpl<double>>(A, b);
 
   auto cost = std::make_shared<QuadraticDistanceCostTpl<double>>(
-      space_, space.neutral(), Q_);
+      space, space.neutral(), Q_);
 
   std::vector<Problem::ConstraintObject> constraints;
   if (M > 0) {
-    constraints.emplace_back(res1, std::make_shared<EqualityType>());
+    constraints.emplace_back(res1, EqualityType{});
   }
 
-  Problem problem(space_, cost, constraints);
+  Problem problem(space, cost, constraints);
 
   SolverType solver(problem);
   solver.setPenalty(1e-4);

--- a/examples/so2.cpp
+++ b/examples/so2.cpp
@@ -15,8 +15,7 @@ using Manifold = PinocchioLieGroup<SO2>;
 using Problem = ProblemTpl<double>;
 
 int main() {
-  auto space_ = std::make_shared<Manifold>();
-  const Manifold &space = *space_;
+  Manifold space;
   Manifold::PointType p0 = space.rand(); // target
   Manifold::PointType p1 = space.rand();
   Manifold::PointType neut = space.neutral();
@@ -36,7 +35,7 @@ int main() {
   Manifold::MatrixXs weights(ndx, ndx);
   weights.setIdentity();
 
-  ManifoldDifferenceToPoint<double> residual(space_, p0);
+  ManifoldDifferenceToPoint<double> residual(space, p0);
   fmt::print("residual val: {}\n", residual(p1));
   fmt::print("residual Jac: {}\n", residual.computeJacobian(p1));
   auto resptr = std::make_shared<ManifoldDifferenceToPoint<double>>(residual);
@@ -50,10 +49,10 @@ int main() {
 
   /// DEFINE A PROBLEM
 
-  auto eq_set = std::make_shared<EqualityConstraintTpl<double>>();
+  EqualityConstraintTpl<double> eq_set;
   std::vector<Problem::ConstraintObject> cstrs;
   cstrs.emplace_back(resptr, eq_set);
-  Problem prob(space_, cost_fun, cstrs);
+  Problem prob(space, cost_fun, cstrs);
 
   /// Test out merit functions
 

--- a/examples/ur5-ik.cpp
+++ b/examples/ur5-ik.cpp
@@ -46,9 +46,9 @@ struct FramePosition : C2FunctionTpl<Scalar> {
   Vector3s ref_;
   mutable Matrix6Xs fJf_;
 
-  FramePosition(Space space, pin::FrameIndex fid, const Vector3s &ref)
-      : Base(space, 3), space_(std::move(space)), data_(space.getModel()),
-        fid_(fid), ref_(ref), fJf_(6, getModel().nv) {
+  FramePosition(const Space &space, pin::FrameIndex fid, const Vector3s &ref)
+      : Base(space, 3), space_(space), data_(space_.getModel()), fid_(fid),
+        ref_(ref), fJf_(6, getModel().nv) {
     fJf_.setZero();
   }
 

--- a/include/proxsuite-nlp/constraint-base.hpp
+++ b/include/proxsuite-nlp/constraint-base.hpp
@@ -21,6 +21,8 @@ public:
   PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
   using ActiveType = Eigen::Matrix<bool, Eigen::Dynamic, 1>;
 
+  ConstraintSetBase() = default;
+
   /// Do not use the vector-Hessian product in the Hessian
   /// for Gauss Newton.
   virtual bool disableGaussNewton() const { return true; }

--- a/include/proxsuite-nlp/constraint-base.hpp
+++ b/include/proxsuite-nlp/constraint-base.hpp
@@ -3,9 +3,11 @@
 #pragma once
 
 #include "proxsuite-nlp/function-base.hpp"
+#include "proxsuite-nlp/third-party/polymorphic_cxx14.hpp"
 
 namespace proxsuite {
 namespace nlp {
+using xyz::polymorphic;
 
 ///
 /// @brief   Base constraint set type.
@@ -123,7 +125,7 @@ template <typename _Scalar> struct ConstraintObjectTpl {
   using ConstraintSet = ConstraintSetBase<Scalar>;
 
   shared_ptr<FunctionType> func_;
-  shared_ptr<ConstraintSet> set_;
+  polymorphic<ConstraintSet> set_;
 
   const FunctionType &func() const { return *func_; }
   int nr() const { return func_->nr(); }
@@ -135,11 +137,11 @@ template <typename _Scalar> struct ConstraintObjectTpl {
   ConstraintObjectTpl &operator=(const ConstraintObjectTpl &) = default;
 
   ConstraintObjectTpl(shared_ptr<FunctionType> func,
-                      shared_ptr<ConstraintSet> set)
+                      const polymorphic<ConstraintSet> &set)
       : func_(func), set_(set) {}
 
   bool operator==(const ConstraintObjectTpl &other) const {
-    return (func_ == other.func_) && (set_ && other.set_);
+    return func_ == other.func_;
   }
 };
 

--- a/include/proxsuite-nlp/constraint-base.hpp
+++ b/include/proxsuite-nlp/constraint-base.hpp
@@ -2,7 +2,6 @@
 /// @copyright Copyright (C) 2022 LAAS-CNRS, INRIA
 #pragma once
 
-#include "proxsuite-nlp/manifold-base.hpp"
 #include "proxsuite-nlp/function-base.hpp"
 
 namespace proxsuite {
@@ -20,7 +19,6 @@ public:
   using Scalar = _Scalar;
   PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
   using ActiveType = Eigen::Matrix<bool, Eigen::Dynamic, 1>;
-  using Self = ConstraintSetBase<Scalar>;
 
   /// Do not use the vector-Hessian product in the Hessian
   /// for Gauss Newton.
@@ -66,7 +64,7 @@ public:
 
   /// @brief Update proximal parameter; this applies to when this class is a
   /// proximal operator that isn't a projection (e.g. \f$ \ell_1 \f$).
-  void setProxParameter(const Scalar mu) {
+  void setProxParameter(const Scalar mu) const {
     mu_ = mu;
     mu_inv_ = 1. / mu;
   };
@@ -110,8 +108,8 @@ public:
   Scalar mu_inv() const { return mu_inv_; }
 
 protected:
-  Scalar mu_ = 0.;
-  Scalar mu_inv_;
+  mutable Scalar mu_ = 0.;
+  mutable Scalar mu_inv_;
 };
 
 /** @brief    Packs a ConstraintSetBase and C2FunctionTpl together.

--- a/include/proxsuite-nlp/constraint-base.hpp
+++ b/include/proxsuite-nlp/constraint-base.hpp
@@ -7,7 +7,6 @@
 
 namespace proxsuite {
 namespace nlp {
-using xyz::polymorphic;
 
 ///
 /// @brief   Base constraint set type.

--- a/include/proxsuite-nlp/constraint-base.hxx
+++ b/include/proxsuite-nlp/constraint-base.hxx
@@ -2,6 +2,8 @@
 /// @copyright Copyright (C) 2022 LAAS-CNRS, INRIA
 #pragma once
 
+#include "proxsuite-nlp/constraint-base.hpp"
+
 namespace proxsuite {
 namespace nlp {
 

--- a/include/proxsuite-nlp/fwd.hpp
+++ b/include/proxsuite-nlp/fwd.hpp
@@ -39,8 +39,27 @@ using std::unique_ptr;
 #include "proxsuite-nlp/deprecated.hpp"
 #include "proxsuite-nlp/warning.hpp"
 
+namespace xyz {
+// fwd-decl for boost override later
+template <class T, class A> class polymorphic;
+} // namespace xyz
+
+/// The following overload for get_pointer is defined here, to avoid conflicts
+/// with other Boost libraries using get_pointer() without seeing this overload
+/// if included later.
+
+namespace boost {
+template <typename T, typename A>
+inline T *get_pointer(::xyz::polymorphic<T, A> const &x) {
+  const T *r = x.operator->();
+  return const_cast<T *>(r);
+}
+} // namespace boost
+
 namespace proxsuite {
 namespace nlp {
+
+using xyz::polymorphic;
 
 template <typename T, typename... Args>
 auto allocate_shared_eigen_aligned(Args &&...args) {

--- a/include/proxsuite-nlp/macros.hpp
+++ b/include/proxsuite-nlp/macros.hpp
@@ -2,6 +2,8 @@
 /// @copyright Copyright (C) 2022 LAAS-CNRS, INRIA
 #pragma once
 
+#include "proxsuite-nlp/deprecated.hpp"
+
 /// @brief Macro empty arg
 #define PROXSUITE_NLP_MACRO_EMPTY_ARG
 
@@ -25,3 +27,29 @@
 #else
 #define PROXSUITE_NLP_INLINE inline
 #endif
+
+/// \brief macros for pragma push/pop/ignore deprecated warnings
+#if defined(__GNUC__) || defined(__clang__)
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_PUSH                                 \
+  PROXSUITE_NLP_PRAGMA(GCC diagnostic push)
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_POP                                  \
+  PROXSUITE_NLP_PRAGMA(GCC diagnostic pop)
+#if defined(__clang__)
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_IGNORED_DELETE_NON_ABSTRACT_NON_VIRTUAL_DTOR
+PROXSUITE_NLP_PRAGMA(GCC diagnostic ignored
+                     "-Wdelete-non-abstract-non-virtual-dtor")
+#else
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_IGNORED_DELETE_NON_ABSTRACT_NON_VIRTUAL_DTOR
+#endif
+#elif defined(WIN32)
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_PUSH _Pragma("warning(push)")
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_POP _Pragma("warning(pop)")
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_IGNORED_DELETE_NON_ABSTRACT_NON_VIRTUAL_DTOR
+#else
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_PUSH
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_POP
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_IGNORED_VARIADIC_MACROS
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_IGNORED_SELF_ASSIGN_OVERLOADED
+#define PROXSUITE_NLP_COMPILER_DIAGNOSTIC_IGNORED_MAYBE_UNINITIALIZED
+#endif // __GNUC__ || __clang__

--- a/include/proxsuite-nlp/manifold-base.txx
+++ b/include/proxsuite-nlp/manifold-base.txx
@@ -3,6 +3,7 @@
 #include "proxsuite-nlp/config.hpp"
 #include "proxsuite-nlp/context.hpp"
 #include "proxsuite-nlp/manifold-base.hpp"
+#include "proxsuite-nlp/modelling/spaces/vector-space.hpp"
 
 namespace proxsuite {
 namespace nlp {

--- a/include/proxsuite-nlp/modelling/constraints/box-constraint.hpp
+++ b/include/proxsuite-nlp/modelling/constraints/box-constraint.hpp
@@ -20,6 +20,10 @@ template <typename Scalar> struct BoxConstraintTpl : ConstraintSetBase<Scalar> {
 
   BoxConstraintTpl(const ConstVectorRef lower, const ConstVectorRef upper)
       : Base(), lower_limit(lower), upper_limit(upper) {}
+  BoxConstraintTpl(const BoxConstraintTpl &) = default;
+  BoxConstraintTpl &operator=(const BoxConstraintTpl &) = default;
+  BoxConstraintTpl(BoxConstraintTpl &&) = default;
+  BoxConstraintTpl &operator=(BoxConstraintTpl &&) = default;
 
   decltype(auto) projection_impl(const ConstVectorRef &z) const {
     return z.cwiseMin(upper_limit).cwiseMax(lower_limit);

--- a/include/proxsuite-nlp/modelling/constraints/constraint-set-product.hpp
+++ b/include/proxsuite-nlp/modelling/constraints/constraint-set-product.hpp
@@ -47,6 +47,11 @@ struct ConstraintSetProductTpl : ConstraintSetBase<Scalar> {
     }
   }
 
+  ConstraintSetProductTpl(const ConstraintSetProductTpl &) = default;
+  ConstraintSetProductTpl &operator=(const ConstraintSetProductTpl &) = default;
+  ConstraintSetProductTpl(ConstraintSetProductTpl &&) = default;
+  ConstraintSetProductTpl &operator=(ConstraintSetProductTpl &&) = default;
+
   Scalar evaluate(const ConstVectorRef &zproj) const override {
     Scalar res = 0.;
     for (std::size_t i = 0; i < m_components.size(); i++) {

--- a/include/proxsuite-nlp/modelling/constraints/constraint-set-product.hpp
+++ b/include/proxsuite-nlp/modelling/constraints/constraint-set-product.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "proxsuite-nlp/constraint-base.hpp"
-#include "proxsuite-nlp/third-party/polymorphic_cxx14.hpp"
 
 namespace proxsuite {
 namespace nlp {

--- a/include/proxsuite-nlp/modelling/constraints/equality-constraint.hpp
+++ b/include/proxsuite-nlp/modelling/constraints/equality-constraint.hpp
@@ -20,6 +20,12 @@ public:
   using Scalar = _Scalar;
   PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
 
+  EqualityConstraintTpl() = default;
+  EqualityConstraintTpl(const EqualityConstraintTpl &) = default;
+  EqualityConstraintTpl &operator=(const EqualityConstraintTpl &) = default;
+  EqualityConstraintTpl(EqualityConstraintTpl &&) = default;
+  EqualityConstraintTpl &operator=(EqualityConstraintTpl &&) = default;
+
   using Base = ConstraintSetBase<Scalar>;
   using ActiveType = typename Base::ActiveType;
 

--- a/include/proxsuite-nlp/modelling/constraints/l1-penalty.hpp
+++ b/include/proxsuite-nlp/modelling/constraints/l1-penalty.hpp
@@ -19,6 +19,12 @@ struct NonsmoothPenaltyL1Tpl : ConstraintSetBase<_Scalar> {
   using Scalar = _Scalar;
   PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
 
+  NonsmoothPenaltyL1Tpl() = default;
+  NonsmoothPenaltyL1Tpl(const NonsmoothPenaltyL1Tpl &) = default;
+  NonsmoothPenaltyL1Tpl &operator=(const NonsmoothPenaltyL1Tpl &) = default;
+  NonsmoothPenaltyL1Tpl(NonsmoothPenaltyL1Tpl &&) = default;
+  NonsmoothPenaltyL1Tpl &operator=(NonsmoothPenaltyL1Tpl &&) = default;
+
   using Base = ConstraintSetBase<Scalar>;
   using ActiveType = typename Base::ActiveType;
   using Base::mu_;

--- a/include/proxsuite-nlp/modelling/constraints/negative-orthant.hpp
+++ b/include/proxsuite-nlp/modelling/constraints/negative-orthant.hpp
@@ -20,6 +20,12 @@ struct NegativeOrthantTpl : ConstraintSetBase<_Scalar> {
   using Scalar = _Scalar;
   PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
 
+  NegativeOrthantTpl() = default;
+  NegativeOrthantTpl(const NegativeOrthantTpl &) = default;
+  NegativeOrthantTpl &operator=(const NegativeOrthantTpl &) = default;
+  NegativeOrthantTpl(NegativeOrthantTpl &&) = default;
+  NegativeOrthantTpl &operator=(NegativeOrthantTpl &&) = default;
+
   using Base = ConstraintSetBase<Scalar>;
   using ActiveType = typename Base::ActiveType;
 

--- a/include/proxsuite-nlp/modelling/costs/squared-distance.hpp
+++ b/include/proxsuite-nlp/modelling/costs/squared-distance.hpp
@@ -18,31 +18,31 @@ template <typename _Scalar>
 struct QuadraticDistanceCostTpl : QuadraticResidualCostTpl<_Scalar> {
   using Scalar = _Scalar;
   PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar);
-  using FunctionType = ManifoldDifferenceToPoint<Scalar>;
+  using StateResidual = ManifoldDifferenceToPoint<Scalar>;
   using Manifold = ManifoldAbstractTpl<Scalar>;
   using Base = QuadraticResidualCostTpl<Scalar>;
   using Base::residual_;
   using Base::weights_;
 
-  QuadraticDistanceCostTpl(const shared_ptr<Manifold> &space,
+  QuadraticDistanceCostTpl(const polymorphic<Manifold> &space,
                            const ConstVectorRef &target,
                            const ConstMatrixRef &weights)
-      : Base(std::make_shared<FunctionType>(space, target), weights) {}
+      : Base(std::make_shared<StateResidual>(space, target), weights) {}
 
-  QuadraticDistanceCostTpl(const shared_ptr<Manifold> &space,
+  QuadraticDistanceCostTpl(const polymorphic<Manifold> &space,
                            const ConstVectorRef &target)
       : QuadraticDistanceCostTpl(
             space, target, MatrixXs::Identity(space->ndx(), space->ndx())) {}
 
-  QuadraticDistanceCostTpl(const shared_ptr<Manifold> &space)
+  QuadraticDistanceCostTpl(const polymorphic<Manifold> &space)
       : QuadraticDistanceCostTpl(space, space->neutral()) {}
 
   ConstVectorRef getTarget() const {
-    return std::static_pointer_cast<FunctionType>(residual_)->target_;
+    return static_cast<StateResidual *>(residual_.get())->target_;
   }
 
   void updateTarget(const ConstVectorRef &x) {
-    std::static_pointer_cast<FunctionType>(residual_)->target_ = x;
+    static_cast<StateResidual *>(residual_.get())->target_ = x;
   }
 };
 

--- a/include/proxsuite-nlp/modelling/residuals/linear.hpp
+++ b/include/proxsuite-nlp/modelling/residuals/linear.hpp
@@ -3,9 +3,11 @@
 #include "proxsuite-nlp/function-base.hpp"
 #include "proxsuite-nlp/function-ops.hpp"
 #include "proxsuite-nlp/modelling/residuals/state-residual.hpp"
+#include "proxsuite-nlp/third-party/polymorphic_cxx14.hpp"
 
 namespace proxsuite {
 namespace nlp {
+using xyz::polymorphic;
 
 /**
  * @brief Linear residuals \f$r(x) = Ax + b\f$.
@@ -44,7 +46,7 @@ struct LinearFunctionDifferenceToPoint : ComposeFunctionTpl<_Scalar> {
 
   using Manifold = ManifoldAbstractTpl<Scalar>;
 
-  LinearFunctionDifferenceToPoint(const shared_ptr<Manifold> &space,
+  LinearFunctionDifferenceToPoint(const polymorphic<Manifold> &space,
                                   const ConstVectorRef &target,
                                   const ConstMatrixRef &A,
                                   const ConstVectorRef &b)

--- a/include/proxsuite-nlp/modelling/residuals/linear.hpp
+++ b/include/proxsuite-nlp/modelling/residuals/linear.hpp
@@ -7,7 +7,6 @@
 
 namespace proxsuite {
 namespace nlp {
-using xyz::polymorphic;
 
 /**
  * @brief Linear residuals \f$r(x) = Ax + b\f$.

--- a/include/proxsuite-nlp/modelling/residuals/state-residual.hpp
+++ b/include/proxsuite-nlp/modelling/residuals/state-residual.hpp
@@ -10,7 +10,6 @@
 
 namespace proxsuite {
 namespace nlp {
-using xyz::polymorphic;
 
 /**
  * Constraint function to be equal to a given element of a space.

--- a/include/proxsuite-nlp/modelling/residuals/state-residual.hpp
+++ b/include/proxsuite-nlp/modelling/residuals/state-residual.hpp
@@ -6,9 +6,11 @@
 
 #include "proxsuite-nlp/function-base.hpp"
 #include "proxsuite-nlp/manifold-base.hpp"
+#include "proxsuite-nlp/third-party/polymorphic_cxx14.hpp"
 
 namespace proxsuite {
 namespace nlp {
+using xyz::polymorphic;
 
 /**
  * Constraint function to be equal to a given element of a space.
@@ -27,9 +29,9 @@ public:
 
   /// Target point on the space.
   typename Manifold::PointType target_;
-  shared_ptr<Manifold> space_;
+  polymorphic<Manifold> space_;
 
-  ManifoldDifferenceToPoint(const shared_ptr<Manifold> &space,
+  ManifoldDifferenceToPoint(const polymorphic<Manifold> &space,
                             const ConstVectorRef &target)
       : Base(space->nx(), space->ndx(), space->ndx()), target_(target),
         space_(space) {

--- a/include/proxsuite-nlp/modelling/spaces/cartesian-product.hpp
+++ b/include/proxsuite-nlp/modelling/spaces/cartesian-product.hpp
@@ -31,8 +31,8 @@ public:
 
   inline std::size_t numComponents() const { return m_components.size(); }
 
-  inline void addComponent(const polymorphic<Base> &c) {
-    m_components.push_back(c);
+  template <class Concrete> inline void addComponent(const Concrete &c) {
+    m_components.emplace_back(c);
   }
 
   inline void addComponent(const CartesianProductTpl &other) {

--- a/include/proxsuite-nlp/modelling/spaces/cartesian-product.hpp
+++ b/include/proxsuite-nlp/modelling/spaces/cartesian-product.hpp
@@ -140,6 +140,14 @@ auto operator*(const PolymorphicManifold<T> &left,
   return right * left;
 }
 
+template <typename T>
+auto operator*(const CartesianProductTpl<T> &left,
+               const CartesianProductTpl<T> &right) {
+  CartesianProductTpl<T> out{left};
+  out.addComponent(right);
+  return out;
+}
+
 } // namespace nlp
 } // namespace proxsuite
 

--- a/include/proxsuite-nlp/modelling/spaces/cartesian-product.hpp
+++ b/include/proxsuite-nlp/modelling/spaces/cartesian-product.hpp
@@ -41,6 +41,10 @@ public:
   }
 
   CartesianProductTpl() = default;
+  CartesianProductTpl(const CartesianProductTpl &) = default;
+  CartesianProductTpl &operator=(const CartesianProductTpl &) = default;
+  CartesianProductTpl(CartesianProductTpl &&) = default;
+  CartesianProductTpl &operator=(CartesianProductTpl &&) = default;
 
   CartesianProductTpl(const std::vector<polymorphic<Base>> &components)
       : m_components(components) {}

--- a/include/proxsuite-nlp/modelling/spaces/cartesian-product.hpp
+++ b/include/proxsuite-nlp/modelling/spaces/cartesian-product.hpp
@@ -8,7 +8,6 @@
 namespace proxsuite {
 namespace nlp {
 namespace {
-using xyz::polymorphic;
 /// Typedef in anon namespace for use in rest of file.
 template <typename T>
 using PolymorphicManifold = polymorphic<ManifoldAbstractTpl<T>>;

--- a/include/proxsuite-nlp/modelling/spaces/cartesian-product.hpp
+++ b/include/proxsuite-nlp/modelling/spaces/cartesian-product.hpp
@@ -40,7 +40,7 @@ public:
     }
   }
 
-  CartesianProductTpl() {}
+  CartesianProductTpl() = default;
 
   CartesianProductTpl(const std::vector<polymorphic<Base>> &components)
       : m_components(components) {}

--- a/include/proxsuite-nlp/modelling/spaces/multibody.hpp
+++ b/include/proxsuite-nlp/modelling/spaces/multibody.hpp
@@ -25,6 +25,10 @@ public:
   PROXSUITE_NLP_DEFINE_MANIFOLD_TYPES(Base)
 
   MultibodyConfiguration(const ModelType &model) : model_(model) {};
+  MultibodyConfiguration(const MultibodyConfiguration &) = default;
+  MultibodyConfiguration &operator=(const MultibodyConfiguration &) = default;
+  MultibodyConfiguration(MultibodyConfiguration &&) = default;
+  MultibodyConfiguration &operator=(MultibodyConfiguration &&) = default;
 
   const ModelType &getModel() const { return model_; }
 
@@ -115,6 +119,10 @@ struct MultibodyPhaseSpace
 
   MultibodyPhaseSpace(const ModelType &model)
       : TangentBundleTpl<ConfigSpace>(ConfigSpace(model)) {}
+  MultibodyPhaseSpace(const MultibodyPhaseSpace &) = default;
+  MultibodyPhaseSpace &operator=(const MultibodyPhaseSpace &) = default;
+  MultibodyPhaseSpace(MultibodyPhaseSpace &&) = default;
+  MultibodyPhaseSpace &operator=(MultibodyPhaseSpace &&) = default;
 };
 
 } // namespace nlp

--- a/include/proxsuite-nlp/problem-base.hpp
+++ b/include/proxsuite-nlp/problem-base.hpp
@@ -23,7 +23,7 @@ public:
   using Workspace = WorkspaceTpl<Scalar>;
 
   /// The working manifold \f$M\f$.
-  shared_ptr<Manifold> manifold_;
+  polymorphic<Manifold> manifold_;
   /// The cost function.
   shared_ptr<CostType> cost_;
   /// The set of constraints.
@@ -32,10 +32,11 @@ public:
   const CostType &cost() const { return *cost_; }
   const Manifold &manifold() const { return *manifold_; }
 
-  ProblemTpl(shared_ptr<Manifold> manifold, shared_ptr<CostType> cost,
+  template <class U>
+  ProblemTpl(U &&manifold, shared_ptr<CostType> cost,
              const std::vector<ConstraintObject> &constraints = {})
-      : manifold_(manifold), cost_(cost), constraints_(constraints),
-        nc_total_(0) {
+      : manifold_(std::forward<U>(manifold)), cost_(cost),
+        constraints_(constraints), nc_total_(0) {
     reset_constraint_dim_vars();
   }
 

--- a/include/proxsuite-nlp/problem-base.hpp
+++ b/include/proxsuite-nlp/problem-base.hpp
@@ -1,5 +1,5 @@
 /// @file
-/// @copyright Copyright (C) 2022 LAAS-CNRS, INRIA
+/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, INRIA
 #pragma once
 
 #include "proxsuite-nlp/manifold-base.hpp"
@@ -16,7 +16,6 @@ public:
 
   /// Generic constraint type
   using ConstraintObject = ConstraintObjectTpl<Scalar>;
-  using ConstraintPtr = shared_ptr<ConstraintObject>;
   /// Cost function type
   using CostType = CostFunctionBaseTpl<Scalar>;
   using Manifold = ManifoldAbstractTpl<Scalar>;

--- a/packaging/conda/proxsuite-nlp-release/meta.yaml
+++ b/packaging/conda/proxsuite-nlp-release/meta.yaml
@@ -25,6 +25,8 @@ requirements:
     - cmake
     - clang  # [win]
     - ninja
+    - libgomp       # [linux]
+    - llvm-openmp   # [osx]
   host:
     - eigen
     - eigenpy

--- a/src/constraint-set-product.cpp
+++ b/src/constraint-set-product.cpp
@@ -2,6 +2,7 @@
 
 namespace proxsuite {
 namespace nlp {
-template struct ConstraintSetProductTpl<context::Scalar>;
+template struct PROXSUITE_NLP_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ConstraintSetProductTpl<context::Scalar>;
 } // namespace nlp
 } // namespace proxsuite

--- a/tests/costs.cpp
+++ b/tests/costs.cpp
@@ -43,10 +43,10 @@ BOOST_AUTO_TEST_SUITE(cost)
 #ifdef PROXSUITE_NLP_WITH_PINOCCHIO
 
 BOOST_AUTO_TEST_CASE(test_cost_sum, *utf::tolerance(1e-10)) {
-  auto space = std::make_shared<SE2>();
-  auto x0 = space->neutral();
-  auto x1 = space->rand();
-  auto x2 = space->rand();
+  SE2 space;
+  auto x0 = space.neutral();
+  auto x1 = space.rand();
+  auto x2 = space.rand();
 
   CostPtr cost1 = std::make_shared<QuadraticDistanceCostTpl<double>>(space, x0);
   CostPtr cost2 = std::make_shared<QuadraticDistanceCostTpl<double>>(space, x1);
@@ -70,7 +70,6 @@ BOOST_AUTO_TEST_CASE(test_cost_sum, *utf::tolerance(1e-10)) {
 }
 
 BOOST_AUTO_TEST_CASE(test_cast_cost) {
-  auto space = std::make_shared<SE2>();
   auto fun = std::make_shared<CustomC2Func>();
   CostPtr cost = downcast_function_to_cost<Scalar>(fun);
 

--- a/tests/manifolds.cpp
+++ b/tests/manifolds.cpp
@@ -4,7 +4,12 @@
 #include "proxsuite-nlp/modelling/spaces/cartesian-product.hpp"
 
 #ifdef PROXSUITE_NLP_WITH_PINOCCHIO
+#include <pinocchio/config.hpp>
+#if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
+#include <pinocchio/multibody/sample-models.hpp>
+#else
 #include <pinocchio/parsers/sample-models.hpp>
+#endif // PINOCCHIO_VERSION_AT_LEAST
 #include "proxsuite-nlp/modelling/spaces/pinocchio-groups.hpp"
 #include "proxsuite-nlp/modelling/spaces/multibody.hpp"
 #endif

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -25,7 +25,9 @@ if(NOT pytest_FOUND)
   message(FATAL_ERROR "Python pytest package missing. You can install it with: pip install pytest")
 endif()
 
-set(PYTHON_TESTS test_1d_funs.py test_costs.py test_functions.py test_manifolds.py test_print.py)
+set(PYTHON_TESTS test_1d_funs.py test_costs.py test_functions.py test_manifolds.py
+                 test_polymorphic.py test_print.py
+)
 
 message(STATUS "Python tests: ${PYTHON_TESTS}")
 

--- a/tests/python/polymorphic_test.cpp
+++ b/tests/python/polymorphic_test.cpp
@@ -64,7 +64,15 @@ struct poly_store {
   PolyX x;
 };
 
-VecPolyX create_vec_poly() { return {Y(), Y(), Z()}; }
+struct vec_store {
+  void add(const PolyX &x) { values.emplace_back(x); }
+  const auto &get() const { return values; }
+
+  auto get_copy() const { return values; }
+
+private:
+  VecPolyX values;
+};
 
 PolyX getY() { return PolyX(Y()); }
 PolyX getZ() { return PolyX(Z()); }
@@ -112,7 +120,6 @@ BOOST_PYTHON_MODULE(polymorphic_test) {
 
   bp::def("getY", &getY);
   bp::def("getZ", &getZ);
-  bp::def("create_vec_poly", &create_vec_poly);
   bp::def("poly_passthrough", &poly_passthrough, "x"_a);
   bp::def("call_method", &call_method, bp::args("x"));
   bp::def("set_return", &set_return,
@@ -130,4 +137,10 @@ BOOST_PYTHON_MODULE(polymorphic_test) {
 
   bp::class_<poly_store>("poly_store", bp::init<const PolyX &>(("self"_a, "x")))
       .def_readonly("x", &poly_store::x);
+
+  bp::class_<vec_store>("vec_store", bp::init<>())
+      .def("add", &vec_store::add, ("self"_a, "x"))
+      .def("get", &vec_store::get, ("self"_a),
+           bp::return_internal_reference<>())
+      .def("get_copy", &vec_store::get_copy, ("self"_a));
 }

--- a/tests/python/polymorphic_test.cpp
+++ b/tests/python/polymorphic_test.cpp
@@ -36,12 +36,16 @@ VecPolyX create_vec_poly() { return {Y(), Z(), Z()}; }
 PolyX getY() { return PolyX(Y()); }
 PolyX getZ() { return PolyX(Z()); }
 
+PolyX poly_passthrough(const PolyX &x) { return x; }
+
 BOOST_PYTHON_MODULE(polymorphic_test) {
   register_polymorphic_to_python<PolyX>();
 
   bp::class_<X, boost::noncopyable>("X", bp::init<>()).def("name", &X::name);
   bp::class_<Y, bp::bases<X>>("Y", bp::init<>());
+  bp::implicitly_convertible<Y, PolyX>();
   bp::class_<Z, bp::bases<X>>("Z", bp::init<>());
+  bp::implicitly_convertible<Z, PolyX>();
 
   eigenpy::StdVectorPythonVisitor<VecPolyX>::expose(
       "VecPolyX",
@@ -50,6 +54,7 @@ BOOST_PYTHON_MODULE(polymorphic_test) {
   bp::def("getY", &getY);
   bp::def("getZ", &getZ);
   bp::def("create_vec_poly", &create_vec_poly);
+  bp::def("poly_passthrough", &poly_passthrough, "x"_a);
 
   bp::class_<poly_use_base>("poly_use_base", bp::no_init)
       .def(bp::init<const Y &>(bp::args("self", "t")))

--- a/tests/python/polymorphic_test.cpp
+++ b/tests/python/polymorphic_test.cpp
@@ -31,6 +31,16 @@ struct PyX final : X, bp::wrapper<X> {
   }
 };
 
+struct PyY final : Y, bp::wrapper<Y> {
+  std::string name() const override {
+    if (bp::override f = get_override("name")) {
+      return f();
+    }
+    return default_name();
+  }
+  std::string default_name() const { return Y::name(); }
+};
+
 using PolyX = xyz::polymorphic<X>;
 using PolyY = xyz::polymorphic<Y>;
 using VecPolyX = std::vector<PolyX>;
@@ -82,7 +92,8 @@ BOOST_PYTHON_MODULE(polymorphic_test) {
   bp::class_<PyX, boost::noncopyable>("X", bp::init<>())
       .def("name", &X::name)
       .def(PolymorphicVisitor<PolyX>());
-  bp::class_<Y, bp::bases<X>>("Y", bp::init<>())
+  bp::class_<PyY, bp::bases<X>, boost::noncopyable>("Y", bp::init<>())
+      .def("name", &Y::name, &PyY::default_name)
       .def(PolymorphicVisitor<PolyX>());
 
   bp::class_<Z, bp::bases<Y>>("Z", bp::init<>())

--- a/tests/python/polymorphic_test.cpp
+++ b/tests/python/polymorphic_test.cpp
@@ -129,17 +129,24 @@ BOOST_PYTHON_MODULE(polymorphic_test) {
       .def_readwrite("x", &X_wrap_store::x);
 
   bp::class_<poly_use_base>("poly_use_base", bp::no_init)
-      .def(bp::init<const Y &>(bp::args("self", "t")))
-      .def(bp::init<const Z &>(bp::args("self", "t")))
-      .def(bp::init<const PyX &>(bp::args("self", "t")))
-      .def(bp::init<const PyY &>(bp::args("self", "t")))
+      .def(bp::init<const Y &>(
+          bp::args("self", "t"))[bp::with_custodian_and_ward<1, 2>()])
+      .def(bp::init<const Z &>(
+          bp::args("self", "t"))[bp::with_custodian_and_ward<1, 2>()])
+      .def(bp::init<const PyX &>(
+          bp::args("self", "t"))[bp::with_custodian_and_ward<1, 2>()])
+      .def(bp::init<const PyY &>(
+          bp::args("self", "t"))[bp::with_custodian_and_ward<1, 2>()])
       .def_readonly("x", &poly_use_base::x);
 
-  bp::class_<poly_store>("poly_store", bp::init<const PolyX &>(("self"_a, "x")))
+  bp::class_<poly_store>(
+      "poly_store", bp::init<const PolyX &>(
+                        ("self"_a, "x"))[bp::with_custodian_and_ward<1, 2>()])
       .def_readonly("x", &poly_store::x);
 
   bp::class_<vec_store>("vec_store", bp::init<>())
-      .def("add", &vec_store::add, ("self"_a, "x"))
+      .def("add", &vec_store::add, ("self"_a, "x"),
+           bp::with_custodian_and_ward<1, 2>())
       .def("get", &vec_store::get, ("self"_a),
            bp::return_internal_reference<>())
       .def("get_copy", &vec_store::get_copy, ("self"_a));

--- a/tests/python/polymorphic_test.cpp
+++ b/tests/python/polymorphic_test.cpp
@@ -38,6 +38,10 @@ PolyX getZ() { return PolyX(Z()); }
 
 PolyX poly_passthrough(const PolyX &x) { return x; }
 
+static PolyX static_x = PolyX{Y()};
+
+const PolyX &get_const_y_poly_ref() { return static_x; }
+
 BOOST_PYTHON_MODULE(polymorphic_test) {
   register_polymorphic_to_python<PolyX>();
 
@@ -55,6 +59,8 @@ BOOST_PYTHON_MODULE(polymorphic_test) {
   bp::def("getZ", &getZ);
   bp::def("create_vec_poly", &create_vec_poly);
   bp::def("poly_passthrough", &poly_passthrough, "x"_a);
+  bp::def("get_const_y_poly_ref", &get_const_y_poly_ref,
+          bp::return_value_policy<bp::reference_existing_object>());
 
   bp::class_<poly_use_base>("poly_use_base", bp::no_init)
       .def(bp::init<const Y &>(bp::args("self", "t")))

--- a/tests/python/polymorphic_test.cpp
+++ b/tests/python/polymorphic_test.cpp
@@ -65,6 +65,8 @@ struct poly_store {
 };
 
 struct vec_store {
+  vec_store() = default;
+  vec_store(const std::vector<PolyX> &x) : values(x) {}
   void add(const PolyX &x) { values.emplace_back(x); }
   const auto &get() const { return values; }
 
@@ -145,6 +147,8 @@ BOOST_PYTHON_MODULE(polymorphic_test) {
       .def_readonly("x", &poly_store::x);
 
   bp::class_<vec_store>("vec_store", bp::init<>())
+      .def(bp::init<const std::vector<PolyX> &>(bp::args(
+          "self", "vec"))[with_custodian_and_ward_list_content<1, 2>()])
       .def("add", &vec_store::add, ("self"_a, "x"),
            bp::with_custodian_and_ward<1, 2>())
       .def("get", &vec_store::get, ("self"_a),

--- a/tests/python/polymorphic_test.cpp
+++ b/tests/python/polymorphic_test.cpp
@@ -5,24 +5,25 @@ using namespace proxsuite::nlp::python;
 
 struct X {
   ~X() = default;
-  virtual std::string name() { return "X"; }
+  virtual std::string name() const { return "X"; }
   X() = default;
 
 protected:
   X(const X &) = default;
 };
 
-struct Y final : X {
+struct Y : X {
   Y() : X() {}
-  std::string name() override { return "Y"; }
+  std::string name() const override { return "Y"; }
 };
 
-struct Z final : X {
-  Z() : X() {}
-  std::string name() override { return "Z"; }
+struct W final : Y {
+  W() : Y() {}
+  std::string name() const override { return "W (Y)"; }
 };
 
 using PolyX = xyz::polymorphic<X>;
+using PolyY = xyz::polymorphic<Y>;
 using VecPolyX = std::vector<PolyX>;
 
 struct poly_use_base {
@@ -31,10 +32,15 @@ struct poly_use_base {
   PolyX x;
 };
 
-VecPolyX create_vec_poly() { return {Y(), Z(), Z()}; }
+struct poly_store {
+  poly_store(const PolyX &x) : x(x) {}
+  PolyX x;
+};
+
+VecPolyX create_vec_poly() { return {Y(), Y(), W()}; }
 
 PolyX getY() { return PolyX(Y()); }
-PolyX getZ() { return PolyX(Z()); }
+PolyX getW() { return PolyX(W()); }
 
 PolyX poly_passthrough(const PolyX &x) { return x; }
 
@@ -42,29 +48,41 @@ static PolyX static_x = PolyX{Y()};
 
 const PolyX &get_const_y_poly_ref() { return static_x; }
 
+const PolyX &set_return(PolyX x) {
+  static_x = x;
+  return static_x;
+}
+
 BOOST_PYTHON_MODULE(polymorphic_test) {
   register_polymorphic_to_python<PolyX>();
+  register_polymorphic_to_python<PolyY>();
 
   bp::class_<X, boost::noncopyable>("X", bp::init<>()).def("name", &X::name);
   bp::class_<Y, bp::bases<X>>("Y", bp::init<>());
-  bp::implicitly_convertible<Y, PolyX>();
-  bp::class_<Z, bp::bases<X>>("Z", bp::init<>());
-  bp::implicitly_convertible<Z, PolyX>();
+
+  bp::class_<W, bp::bases<Y>>("W", bp::init<>());
 
   eigenpy::StdVectorPythonVisitor<VecPolyX>::expose(
       "VecPolyX",
       eigenpy::details::overload_base_get_item_for_std_vector<VecPolyX>());
 
   bp::def("getY", &getY);
-  bp::def("getZ", &getZ);
+  bp::def("getW", &getW);
   bp::def("create_vec_poly", &create_vec_poly);
   bp::def("poly_passthrough", &poly_passthrough, "x"_a);
+  bp::def("call_method", &call_method, bp::args("x"));
   bp::def("get_const_y_poly_ref", &get_const_y_poly_ref,
+          bp::return_value_policy<bp::reference_existing_object>());
+  bp::def("set_return", &set_return,
           bp::return_value_policy<bp::reference_existing_object>());
 
   bp::class_<poly_use_base>("poly_use_base", bp::no_init)
       .def(bp::init<const Y &>(bp::args("self", "t")))
-      .def(bp::init<const Z &>(bp::args("self", "t")))
+      .def(bp::init<const W &>(bp::args("self", "t")))
       .add_property("x", bp::make_getter(&poly_use_base::x,
+                                         bp::return_internal_reference<>()));
+
+  bp::class_<poly_store>("poly_store", bp::init<const PolyX &>(("self"_a, "x")))
+      .add_property("x", bp::make_getter(&poly_store::x,
                                          bp::return_internal_reference<>()));
 }

--- a/tests/python/test_manifolds.py
+++ b/tests/python/test_manifolds.py
@@ -32,6 +32,14 @@ def test_cartesian_product():
     print(prod.getComponent(0), prod.getComponent(1))
     assert prod.num_components == 2
 
+    prod_from_vec = CartesianProduct([space1, space2])
+    assert prod_from_vec.nx == (space1.nx + space2.nx)
+    assert prod_from_vec.ndx == (space1.ndx + space2.ndx)
+    print(prod_from_vec.nx, prod_from_vec.ndx)
+    print(prod_from_vec.getComponent(0), prod_from_vec.getComponent(1))
+    assert prod_from_vec.num_components == 2
+
+
     x0 = prod.neutral()
     x1 = prod.rand()
     assert x0.size == prod.nx

--- a/tests/python/test_manifolds.py
+++ b/tests/python/test_manifolds.py
@@ -39,7 +39,6 @@ def test_cartesian_product():
     print(prod_from_vec.getComponent(0), prod_from_vec.getComponent(1))
     assert prod_from_vec.num_components == 2
 
-
     x0 = prod.neutral()
     x1 = prod.rand()
     assert x0.size == prod.nx

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -19,6 +19,11 @@ class DerX(X):
         return "My name is DerX and I'm from Python!"
 
 
+class DerY(Y):
+    def name(self):
+        return "DerivedY"
+
+
 assert isinstance(getY(), Y)
 assert isinstance(getZ(), Z)
 assert issubclass(Y, X)
@@ -33,6 +38,9 @@ call_method(z)
 d = DerX()
 print(d)
 call_method(d)
+e = DerY()
+print(e)
+call_method(e)
 
 dstore = X_wrap_store(d)
 print("dstore.x:", dstore.x)
@@ -41,33 +49,47 @@ print("dstore.x:", dstore.x)
 def test_poly_base():
     print("=== test_poly_base ===")
     b = poly_use_base(y)
-    print(b.x)
-    assert isinstance(b.x, Y)
+    x = b.x
+    print(x)
+    assert isinstance(x, Y)
 
     b = poly_use_base(z)
-    print(b.x)
-    assert isinstance(b.x, Z)
+    x = b.x
+    print(x)
+    assert isinstance(x, Z)
 
     b = poly_use_base(d)
     x = b.x
     print(x, x.name())
     assert isinstance(x, DerX)
 
+    b = poly_use_base(e)
+    x = b.x
+    print(x, x.name())
+    assert isinstance(x, DerY)
+
 
 def test_poly_store():
     print("=== test_poly_store ===")
     b = poly_store(y)
-    print(b.x)
-    assert isinstance(b.x, X)
-    assert isinstance(b.x, Y)
+    x = b.x
+    print(x)
+    assert isinstance(x, X)
+    assert isinstance(x, Y)
 
     print("poly_store(z)")
     b = poly_store(z)
-    print(b.x)
-    assert isinstance(b.x, Z)
+    x = b.x
+    print(x)
+    assert isinstance(x, Z)
 
     b = poly_store(d)
-    print(b.x, b.x.name())
+    x = b.x
+    print(x, x.name())
+
+    b = poly_store(e)
+    x = b.x
+    print(x, x.name())
 
 
 test_poly_base()
@@ -91,6 +113,10 @@ assert isinstance(pz, Y)
 
 pd = poly_passthrough(d)
 print("d", pd)
+assert isinstance(pd, DerX)
+
+pe = poly_passthrough(e)
+assert isinstance(pe, DerY)
 
 print("Set static and return:")
 r_stat = set_return(z)

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -7,10 +7,10 @@ from polymorphic_test import (
     X_wrap_store,
     poly_use_base,
     poly_store,
-    create_vec_poly,
     set_return,
     poly_passthrough,
     call_method,
+    vec_store,
 )
 
 
@@ -20,6 +20,9 @@ class DerX(X):
 
 
 class DerY(Y):
+    def __init__(self):
+        super().__init__()
+
     def name(self):
         return "DerivedY"
 
@@ -95,12 +98,6 @@ def test_poly_store():
 test_poly_base()
 test_poly_store()
 
-print("Create vector<PolyX>")
-vec = create_vec_poly()
-assert len(vec) == 3
-print(vec[0])
-print(vec.tolist())
-
 print("passthrough:")
 py = poly_passthrough(y)
 assert isinstance(py, Y)
@@ -110,6 +107,14 @@ pz = poly_passthrough(z)
 print("z", pz)
 assert isinstance(pz, Z)
 assert isinstance(pz, Y)
+
+print("=== vec_store ===")
+vs = vec_store()
+vs.add(z)
+vs.add(d)
+vs.add(e)
+print(vs.get().tolist())
+assert len(vs.get()) == 3
 
 # poly_passthrough() returns a copy, and the to-value converter for Poly does not test for bp::wrapper objects
 # pd = poly_passthrough(d)

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -49,8 +49,9 @@ def test_poly_base():
     assert isinstance(b.x, Z)
 
     b = poly_use_base(d)
-    print(b.x, b.x.name())
-    assert isinstance(b.x, DerX)
+    x = b.x
+    print(x, x.name())
+    assert isinstance(x, DerX)
 
 
 def test_poly_store():

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -1,51 +1,72 @@
 from polymorphic_test import (
     X,
     Y,
-    W,
+    Z,
     getY,
-    getW,
+    getZ,
+    X_wrap_store,
     poly_use_base,
     poly_store,
     create_vec_poly,
     set_return,
     poly_passthrough,
     call_method,
-    get_const_y_poly_ref,
 )
 
+
+class DerX(X):
+    def name(self):
+        return "My name is DerX and I'm from Python!"
+
+
 assert isinstance(getY(), Y)
-assert isinstance(getW(), W)
+assert isinstance(getZ(), Z)
 assert issubclass(Y, X)
-assert issubclass(W, Y)
+assert issubclass(Z, Y)
 
 y = Y()
 print(y)
 call_method(y)
-w = W()
-print(w)
+z = Z()
+print(z)
+call_method(z)
+d = DerX()
+print(d)
+call_method(d)
+
+dstore = X_wrap_store(d)
+print("dstore.x:", dstore.x)
 
 
 def test_poly_base():
-    print("Use base")
+    print("=== test_poly_base ===")
     b = poly_use_base(y)
     print(b.x)
     assert isinstance(b.x, Y)
 
-    b = poly_use_base(w)
+    b = poly_use_base(z)
     print(b.x)
-    assert isinstance(b.x, W)
+    assert isinstance(b.x, Z)
+
+    b = poly_use_base(d)
+    print(b.x, b.x.name())
+    assert isinstance(b.x, DerX)
 
 
 def test_poly_store():
-    print("test_poly_store")
+    print("=== test_poly_store ===")
     b = poly_store(y)
     print(b.x)
+    assert isinstance(b.x, X)
     assert isinstance(b.x, Y)
 
-    b = poly_store(w)
-    # wrong, we get Y
+    print("poly_store(z)")
+    b = poly_store(z)
     print(b.x)
-    assert isinstance(b.x, W)
+    assert isinstance(b.x, Z)
+
+    b = poly_store(d)
+    print(b.x, b.x.name())
 
 
 test_poly_base()
@@ -62,17 +83,18 @@ py = poly_passthrough(y)
 assert isinstance(py, Y)
 print("y", py)
 
-pw = poly_passthrough(w)
-print("w", pw)
-assert isinstance(pw, W)  # error
-assert isinstance(pw, Y)
+pz = poly_passthrough(z)
+print("z", pz)
+assert isinstance(pz, Z)
+assert isinstance(pz, Y)
 
-print("Get static Y:")
-ry_static = get_const_y_poly_ref()
-print(ry_static)
-assert isinstance(ry_static, Y)
+pd = poly_passthrough(d)
+print("d", pd)
 
 print("Set static and return:")
-r_stat = set_return(w)
-print("r_stat (W):", r_stat)
-assert isinstance(r_stat, W)
+r_stat = set_return(z)
+print("r_stat (Z):", r_stat)
+assert isinstance(r_stat, Z)
+r_stat = set_return(d)
+print(r_stat, r_stat.name())
+assert isinstance(r_stat, DerX)

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -126,9 +126,9 @@ def test_vec_store():
     vs_list = vs.get().tolist()
     print(vs_list)
     assert len(vs.get()) == 3
-    assert (isinstance(vs_list[0], Z))
-    assert (isinstance(vs_list[1], DerX))
-    assert (isinstance(vs_list[2], DerY))
+    assert isinstance(vs_list[0], Z)
+    assert isinstance(vs_list[1], DerX)
+    assert isinstance(vs_list[2], DerY)
 
 
 test_poly_base()

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -50,31 +50,46 @@ print("dstore.x:", dstore.x)
 
 
 def test_poly_base():
+    y = Y()
+    z = Z()
+    d = DerX()
+    e = DerY()
+
     print("=== test_poly_base ===")
     b = poly_use_base(y)
+    del y
     x = b.x
     print(x)
     assert isinstance(x, Y)
 
     b = poly_use_base(z)
+    del z
     x = b.x
     print(x)
     assert isinstance(x, Z)
 
     b = poly_use_base(d)
+    del d
     x = b.x
     print(x, x.name())
     assert isinstance(x, DerX)
 
     b = poly_use_base(e)
+    del e
     x = b.x
     print(x, x.name())
     assert isinstance(x, DerY)
 
 
 def test_poly_store():
+    y = Y()
+    z = Z()
+    d = DerX()
+    e = DerY()
+
     print("=== test_poly_store ===")
     b = poly_store(y)
+    del y
     x = b.x
     print(x)
     assert isinstance(x, X)
@@ -82,15 +97,18 @@ def test_poly_store():
 
     print("poly_store(z)")
     b = poly_store(z)
+    del z
     x = b.x
     print(x)
     assert isinstance(x, Z)
 
     b = poly_store(d)
+    del d
     x = b.x
     print(x, x.name())
 
     b = poly_store(e)
+    del e
     x = b.x
     print(x, x.name())
 

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -7,6 +7,7 @@ from polymorphic_test import (
     poly_use_base,
     create_vec_poly,
     poly_passthrough,
+    get_const_y_poly_ref,
 )
 
 assert isinstance(getY(), Y)
@@ -39,3 +40,8 @@ print(py)
 pz = poly_passthrough(z)
 assert isinstance(pz, Z)
 print(pz)
+
+print("Get static Y:")
+ry_static = get_const_y_poly_ref()
+print(ry_static)
+assert isinstance(ry_static, Y)

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -113,8 +113,27 @@ def test_poly_store():
     print(x, x.name())
 
 
+def test_vec_store():
+    z = Z()
+    d = DerX()
+    e = DerY()
+    print("=== vec_store ===")
+    vs = vec_store([z, d])
+    vs.add(e)
+    del z
+    del d
+    del e
+    vs_list = vs.get().tolist()
+    print(vs_list)
+    assert len(vs.get()) == 3
+    assert (isinstance(vs_list[0], Z))
+    assert (isinstance(vs_list[1], DerX))
+    assert (isinstance(vs_list[2], DerY))
+
+
 test_poly_base()
 test_poly_store()
+test_vec_store()
 
 print("passthrough:")
 py = poly_passthrough(y)
@@ -126,13 +145,6 @@ print("z", pz)
 assert isinstance(pz, Z)
 assert isinstance(pz, Y)
 
-print("=== vec_store ===")
-vs = vec_store()
-vs.add(z)
-vs.add(d)
-vs.add(e)
-print(vs.get().tolist())
-assert len(vs.get()) == 3
 
 # poly_passthrough() returns a copy, and the to-value converter for Poly does not test for bp::wrapper objects
 # pd = poly_passthrough(d)

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -111,12 +111,12 @@ print("z", pz)
 assert isinstance(pz, Z)
 assert isinstance(pz, Y)
 
-pd = poly_passthrough(d)
-print("d", pd)
-assert isinstance(pd, DerX)
-
-pe = poly_passthrough(e)
-assert isinstance(pe, DerY)
+# poly_passthrough() returns a copy, and the to-value converter for Poly does not test for bp::wrapper objects
+# pd = poly_passthrough(d)
+# print("d", pd)
+# assert isinstance(pd, DerX)
+# pe = poly_passthrough(e)
+# assert isinstance(pe, DerY)
 
 print("Set static and return:")
 r_stat = set_return(z)

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -1,4 +1,13 @@
-from polymorphic_test import X, Y, Z, getY, getZ, poly_use_base, create_vec_poly
+from polymorphic_test import (
+    X,
+    Y,
+    Z,
+    getY,
+    getZ,
+    poly_use_base,
+    create_vec_poly,
+    poly_passthrough,
+)
 
 assert isinstance(getY(), Y)
 assert isinstance(getZ(), Z)
@@ -6,7 +15,9 @@ assert issubclass(Y, X)
 assert issubclass(Z, X)
 
 y = Y()
+print(y)
 z = Z()
+print(z)
 
 b = poly_use_base(y)
 print(b.x)
@@ -17,6 +28,14 @@ print(b.x)
 assert isinstance(b.x, Z)
 
 vec = create_vec_poly()
-print(len(vec))
+assert len(vec) == 3
 print(vec[0])
 print(vec.tolist())
+
+print("passthrough:")
+py = poly_passthrough(y)
+assert isinstance(py, Y)
+print(py)
+pz = poly_passthrough(z)
+assert isinstance(pz, Z)
+print(pz)

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -1,4 +1,4 @@
-from polymorphic_test import X, Y, Z, getY, getZ, poly_use_base
+from polymorphic_test import X, Y, Z, getY, getZ, poly_use_base, create_vec_poly
 
 assert isinstance(getY(), Y)
 assert isinstance(getZ(), Z)
@@ -15,3 +15,8 @@ assert isinstance(b.x, Y)
 b = poly_use_base(z)
 print(b.x)
 assert isinstance(b.x, Z)
+
+vec = create_vec_poly()
+print(len(vec))
+print(vec[0])
+print(vec.tolist())

--- a/tests/python/test_polymorphic.py
+++ b/tests/python/test_polymorphic.py
@@ -1,33 +1,57 @@
 from polymorphic_test import (
     X,
     Y,
-    Z,
+    W,
     getY,
-    getZ,
+    getW,
     poly_use_base,
+    poly_store,
     create_vec_poly,
+    set_return,
     poly_passthrough,
+    call_method,
     get_const_y_poly_ref,
 )
 
 assert isinstance(getY(), Y)
-assert isinstance(getZ(), Z)
+assert isinstance(getW(), W)
 assert issubclass(Y, X)
-assert issubclass(Z, X)
+assert issubclass(W, Y)
 
 y = Y()
 print(y)
-z = Z()
-print(z)
+call_method(y)
+w = W()
+print(w)
 
-b = poly_use_base(y)
-print(b.x)
-assert isinstance(b.x, Y)
 
-b = poly_use_base(z)
-print(b.x)
-assert isinstance(b.x, Z)
+def test_poly_base():
+    print("Use base")
+    b = poly_use_base(y)
+    print(b.x)
+    assert isinstance(b.x, Y)
 
+    b = poly_use_base(w)
+    print(b.x)
+    assert isinstance(b.x, W)
+
+
+def test_poly_store():
+    print("test_poly_store")
+    b = poly_store(y)
+    print(b.x)
+    assert isinstance(b.x, Y)
+
+    b = poly_store(w)
+    # wrong, we get Y
+    print(b.x)
+    assert isinstance(b.x, W)
+
+
+test_poly_base()
+test_poly_store()
+
+print("Create vector<PolyX>")
 vec = create_vec_poly()
 assert len(vec) == 3
 print(vec[0])
@@ -36,12 +60,19 @@ print(vec.tolist())
 print("passthrough:")
 py = poly_passthrough(y)
 assert isinstance(py, Y)
-print(py)
-pz = poly_passthrough(z)
-assert isinstance(pz, Z)
-print(pz)
+print("y", py)
+
+pw = poly_passthrough(w)
+print("w", pw)
+assert isinstance(pw, W)  # error
+assert isinstance(pw, Y)
 
 print("Get static Y:")
 ry_static = get_const_y_poly_ref()
 print(ry_static)
 assert isinstance(ry_static, Y)
+
+print("Set static and return:")
+r_stat = set_return(w)
+print("r_stat (W):", r_stat)
+assert isinstance(r_stat, W)


### PR DESCRIPTION
Use a custom bp::wrapper type and a custom value_holder (OwningNonOwningHolder) to manage wrapping by deepcopy and avoid manual lifetime management.