### PR TITLE
Set policy CMP0167 and comply to CMP0169 to avoid warnings with CMake 3.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add compatibility with jrl-cmakemodules workspace ([#99](https://github.com/Simple-Robotics/proxsuite-nlp/pull/99))
 
+### Fixed
+- Remove CMake CMP0167 and CMP0169 warnings ([#100](https://github.com/Simple-Robotics/proxsuite-nlp/pull/100))
+
 ## [0.7.0] - 2024-05-14
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,11 @@ set(DOXYGEN_USE_TEMPLATE_CSS YES)
 set(DOXYGEN_HTML_HEADER "${PROJECT_SOURCE_DIR}/doc/header.html")
 set(DOXYGEN_HTML_STYLESHEET "")
 
+# Use BoostConfig module distributed by boost library instead of using FindBoost module distributed
+# by CMake
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 include(${JRL_CMAKE_MODULES}/base.cmake)
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)
 project(${PROJECT_NAME} ${PROJECT_ARGS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,22 +16,15 @@ FetchContent_Declare(
   GIT_PROGRESS TRUE
   EXCLUDE_FROM_ALL SYSTEM
 )
-FetchContent_GetProperties(eigenrand)
-if(NOT eigenrand_POPULATED)
-  set(EIGENRAND_BUILD_TEST
-      OFF
-      CACHE INTERNAL "Enable EigenRand test"
-  )
-  set(EIGENRAND_BUILD_BENCHMARK
-      OFF
-      CACHE INTERNAL "Enable EigenRand benchmark"
-  )
-  FetchContent_Populate(eigenrand)
-  add_library(EigenRand::EigenRand IMPORTED INTERFACE)
-  set_target_properties(
-    EigenRand::EigenRand PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${eigenrand_SOURCE_DIR}
-  )
-endif(NOT eigenrand_POPULATED)
+set(EIGENRAND_BUILD_TEST
+    OFF
+    CACHE INTERNAL "Enable EigenRand test"
+)
+set(EIGENRAND_BUILD_BENCHMARK
+    OFF
+    CACHE INTERNAL "Enable EigenRand benchmark"
+)
+FetchContent_MakeAvailable(eigenrand)
 
 # Add benchmark dependency
 if(BUILD_BENCHMARK)


### PR DESCRIPTION
CMake 3.30 don't package anymore the FindBoost.cmake file. Instead, it encourage to use the BoostModule.cmake distributed by Boost.

To avoid a warning message, we must set the CMP0167 policy to NEW.

CMP0167 deprecate FetchContent_populate.