### PR TITLE
[python] Remove contents of proxsuite-nlp/python/deprecaton-policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Increase minimum version of eigenpy to 3.8.0
+* [python] Header `proxsuite-nlp/python/deprecation-policy.hpp` is now deprecated and simply using-declares the templates from eigenpy's corresponding header (introduced in [3.6.0](https://github.com/stack-of-tasks/eigenpy/releases/tag/v3.6.0))
 
 ## [0.8.0] - 2024-09-16
 

--- a/bindings/python/expose-solver.cpp
+++ b/bindings/python/expose-solver.cpp
@@ -15,7 +15,7 @@ void exposeSolver() {
   using context::ConstVectorRef;
   using context::Problem;
   using context::VectorRef;
-  using eigenpy::deprecation_warning_policy;
+  using eigenpy::deprecated_member;
   using eigenpy::DeprecationType;
   using eigenpy::ReturnInternalStdUniquePtr;
 
@@ -120,13 +120,13 @@ void exposeSolver() {
       .def("setup", &ProxNLPSolver::setup, ("self"_a),
            "Initialize the solver workspace and results.")
       .def("getResults", &ProxNLPSolver::getResults, ("self"_a),
-           deprecation_warning_policy<DeprecationType::DEPRECATION,
-                                      bp::return_internal_reference<>>(
+           deprecated_member<DeprecationType::DEPRECATION,
+                             bp::return_internal_reference<>>(
                "This getter has been deprecated."),
            "Get a reference to the results object.")
       .def("getWorkspace", &ProxNLPSolver::getWorkspace, ("self"_a),
-           deprecation_warning_policy<DeprecationType::DEPRECATION,
-                                      bp::return_internal_reference<>>(
+           deprecated_member<DeprecationType::DEPRECATION,
+                             bp::return_internal_reference<>>(
                "This getter has been deprecated."),
            "Get a reference to the workspace object.")
       .add_property("workspace", bp::make_getter(&ProxNLPSolver::workspace_,

--- a/bindings/python/expose-solver.cpp
+++ b/bindings/python/expose-solver.cpp
@@ -1,7 +1,7 @@
 #include "proxsuite-nlp/python/fwd.hpp"
-#include "proxsuite-nlp/python/deprecation-policy.hpp"
 #include "proxsuite-nlp/prox-solver.hpp"
 #include <eigenpy/std-unique-ptr.hpp>
+#include <eigenpy/deprecation-policy.hpp>
 
 namespace proxsuite {
 namespace nlp {
@@ -15,6 +15,8 @@ void exposeSolver() {
   using context::ConstVectorRef;
   using context::Problem;
   using context::VectorRef;
+  using eigenpy::deprecation_warning_policy;
+  using eigenpy::DeprecationType;
   using eigenpy::ReturnInternalStdUniquePtr;
 
   bp::enum_<VerboseLevel>("VerboseLevel", "Verbose level for the solver.")
@@ -119,11 +121,13 @@ void exposeSolver() {
            "Initialize the solver workspace and results.")
       .def("getResults", &ProxNLPSolver::getResults, ("self"_a),
            deprecation_warning_policy<DeprecationType::DEPRECATION,
-                                      bp::return_internal_reference<>>(),
+                                      bp::return_internal_reference<>>(
+               "This getter has been deprecated."),
            "Get a reference to the results object.")
       .def("getWorkspace", &ProxNLPSolver::getWorkspace, ("self"_a),
            deprecation_warning_policy<DeprecationType::DEPRECATION,
-                                      bp::return_internal_reference<>>(),
+                                      bp::return_internal_reference<>>(
+               "This getter has been deprecated."),
            "Get a reference to the workspace object.")
       .add_property("workspace", bp::make_getter(&ProxNLPSolver::workspace_,
                                                  ReturnInternalStdUniquePtr{}))

--- a/bindings/python/include/proxsuite-nlp/python/deprecation-policy.hpp
+++ b/bindings/python/include/proxsuite-nlp/python/deprecation-policy.hpp
@@ -3,57 +3,17 @@
 //
 #pragma once
 
+#include "proxsuite-nlp/deprecated.hpp"
+#include <eigenpy/deprecation-policy.hpp>
+
+PROXSUITE_NLP_DEPRECATED_HEADER("This header has been deprecated. Use "
+                                "<eigenpy/deprecation-policy.hpp> instead.")
+
 namespace proxsuite {
 namespace nlp {
-namespace bp = boost::python;
-
-enum class DeprecationType { DEPRECATION, FUTURE };
-
-namespace detail {
-
-constexpr PyObject *deprecationTypeToPyObj(DeprecationType dep) {
-  switch (dep) {
-  case DeprecationType::DEPRECATION:
-    return PyExc_DeprecationWarning;
-  case DeprecationType::FUTURE:
-    return PyExc_FutureWarning;
-  }
-}
-
-} // namespace detail
-
-constexpr char defaultDeprecationMessage[] =
-    "This function or attribute has been marked as deprecated, and will be "
-    "removed in the "
-    "future.";
-
-/// @brief A Boost.Python call policy which triggers a Python warning on
-/// precall.
-template <DeprecationType deprecation_type = DeprecationType::DEPRECATION,
-          class BasePolicy = bp::default_call_policies>
-struct deprecation_warning_policy : BasePolicy {
-  using result_converter = typename BasePolicy::result_converter;
-  using argument_package = typename BasePolicy::argument_package;
-
-  deprecation_warning_policy(
-      const std::string &warning_msg = defaultDeprecationMessage)
-      : BasePolicy(), m_what(warning_msg) {}
-
-  std::string what() const { return m_what; }
-
-  const BasePolicy *derived() const {
-    return static_cast<const BasePolicy *>(this);
-  }
-
-  template <class ArgPackage> bool precall(const ArgPackage &args) const {
-    PyErr_WarnEx(detail::deprecationTypeToPyObj(deprecation_type),
-                 m_what.c_str(), 1);
-    return derived()->precall(args);
-  }
-
-private:
-  const std::string m_what;
-};
-
+using eigenpy::deprecated_function;
+using eigenpy::deprecated_member;
+using eigenpy::deprecation_warning_policy;
+using eigenpy::DeprecationType;
 } // namespace nlp
 } // namespace proxsuite


### PR DESCRIPTION
`proxsuite-nlp` requires at least eigenpy 3.6.0, hence we can delegate to eigenpy's relevant header for deprecating exposes classes or functions in the Python bindings.

Merge after #110 