### PR TITLE
Don't link against all pinocchio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - constraint-set.hpp : remove template-id for destructor
+- Only link against needed pinocchio libraries ([#118](https://github.com/Simple-Robotics/proxsuite-nlp/pull/118))
 
 ## [0.10.0] - 2024-10-14
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ function(create_library)
   endif()
 
   if(BUILD_WITH_PINOCCHIO_SUPPORT)
-    target_link_libraries(${PROJECT_NAME} PUBLIC pinocchio::pinocchio)
+    target_link_libraries(${PROJECT_NAME} PUBLIC pinocchio::pinocchio_default)
   endif()
 
   target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,7 +26,7 @@ if(BUILD_WITH_PINOCCHIO_SUPPORT)
   add_proxsuite_nlp_example(ur5-ik.cpp)
   target_link_libraries(
     ${PROJECT_NAME}-example-ur5-ik
-    PUBLIC example-robot-data::example-robot-data
+    PUBLIC example-robot-data::example-robot-data pinocchio::pinocchio_parsers
   )
 endif()
 


### PR DESCRIPTION
The CMake `pinocchio::pinocchio` target link against all pinocchio sublibrary.

Proxsuite-nlp only need pinocchio_default (standard algorithms build with double) and pinocchio_parsers in one example.

Drawback : this fix doesn't support Pinocchio 2.