### PR TITLE
Remove absolute path for boost library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove absolute path for boost library ([#125](https://github.com/Simple-Robotics/proxsuite-nlp/pull/125))
+
 ### Added
 
 - `prox-solver.hpp`: Add more alternatives to the `HessianApprox` enum  ([#92](https://github.com/Simple-Robotics/proxsuite-nlp/pull/92))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove absolute path for boost library ([#125](https://github.com/Simple-Robotics/proxsuite-nlp/pull/125))
+- Remove absolute path for boost library in generated pkg-config file ([#125](https://github.com/Simple-Robotics/proxsuite-nlp/pull/125))
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,7 +414,9 @@ if(BUILD_WITH_PROXSUITE_SUPPORT)
 endif()
 
 pkg_config_append_libs(${PROJECT_NAME})
-pkg_config_append_boost_libs(${BOOST_REQUIRED_COMPONENTS})
+foreach(boostlib ${BOOST_REQUIRED_COMPONENTS})
+  pkg_config_append_libs("boost_${boostlib}")
+endforeach()
 pkg_config_append_cflags("${CFLAGS_DEPENDENCIES}")
 
 # Install catkin package.xml


### PR DESCRIPTION
I encountered the same problem as in pinocchio (https://github.com/stack-of-tasks/pinocchio/issues/2187).
I propose to fix it with the same fix https://github.com/stack-of-tasks/pinocchio/pull/2202
I submitted the same PR in crocoddyl https://github.com/loco-3d/crocoddyl/pull/1353
And I plan to submit the same fix in aligator :smile: